### PR TITLE
Bugfix: If we are editing the step get the question using current parameters

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/controllers/QuestionWizardController.jsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/QuestionWizardController.jsx
@@ -113,9 +113,12 @@ class QuestionWizardController extends ViewController {
       const step = submissionMetadata.type === 'edit-step'
         ? await wdkService.findStep(submissionMetadata.stepId)
         : undefined;
-      const question = await wdkService.getQuestionAndParameters(questionName);
+      const question = await ( step
+        ? wdkService.getQuestionGivenParameters(questionName, step.searchConfig.parameters)
+        : wdkService.getQuestionAndParameters(questionName)
+      );
       const recordClass = await wdkService.findRecordClass(question.outputRecordClassName);
-      const paramValues = step ? step.searchConfig.parameters : getDefaultParamValues({ question });
+      const paramValues = getDefaultParamValues({ question });
       // FIXME Deal with invalid steps
       this.setState(createInitialState(question, recordClass, paramValues), () => {
         document.title = `Search for ${recordClass.displayName} by ${question.displayName}`;


### PR DESCRIPTION
Otherwise the initial state of the filters will be incorrect
This matters on MicrobiomeDB for the MicrobiomeSampleByMetadata question, where there is
a Habitat->Dataset->Samples wizard and a case where a preselected Dataset limits the number of Samples

Fixes https://redmine.apidb.org/issues/40234

Also a refactor: take paramValues from the question once it's correct there, it's the same as step.searchConfig.parameters