### PR TITLE
Contact us screenshot field

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -5,10 +5,12 @@
   "repository": {},
   "license": "MIT",
   "dependencies": {
+    "@types/react-image-crop": "^8.1.2",
     "custom-event-polyfill": "^1.0.7",
+    "icon-font-generator": "^2.1.8",
     "md5": "^2.2.1",
-    "whatwg-fetch": "^3.0.0",
-    "icon-font-generator": "^2.1.8"
+    "react-image-crop": "^8.6.4",
+    "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
     "install": "mkdir -p dist && icon-font-generator icons/* -o dist -n ebrc-icons -p ebrc-icon --normalize --center --csstp ./templates/icons-css.hbs"

--- a/Site/tsconfig.json
+++ b/Site/tsconfig.json
@@ -4,10 +4,16 @@
     "paths": {
       "wdk-client/*": [ "WDKClient/Client/src/*" ],
       "ebrc-client/*": [ "EbrcWebsiteCommon/Site/webapp/wdkCustomization/js/client/*" ],
-      "*": [ "WDKClient/Client/node_modules/*", "WDKClient/Client/node_modules/@types/*"]
+      "*": [
+        "WDKClient/Client/node_modules/*",
+        "WDKClient/Client/node_modules/@types/*",
+        "EbrcWebsiteCommon/Site/node_modules/*",
+        "EbrcWebsiteCommon/Site/node_modules/@types/*"
+      ]
     },
     "typeRoots": [
-      "../../WDKClient/Client/node_modules/@types"
+      "../../WDKClient/Client/node_modules/@types",
+      "EbrcWebsiteCommon/Site/node_modules/@types"
     ]
   },
   "include": [

--- a/Site/webapp/wdkCustomization/js/client/actioncreators/ContactUsActionCreators.js
+++ b/Site/webapp/wdkCustomization/js/client/actioncreators/ContactUsActionCreators.js
@@ -6,6 +6,8 @@ export const CHANGE_CONTEXT = 'contact-us/change-context';
 export const CHANGE_ATTACHMENT_METADATA = 'contact-us/change-attachment-metadata';
 export const ADD_ATTACHMENT_METADATA = 'contact-us/add-attachment-metadata';
 export const REMOVE_ATTACHMENT_METADATA = 'contact-us/remove-attachment-metadata';
+export const ADD_SCREENSHOT_METADATA = 'contact-us/add-screenshot-metadata';
+export const REMOVE_SCREENSHOT_METADATA = 'contact-us/remove-screenshot-metadata';
 export const UPDATE_SUBMITTING_STATUS = 'contact-us/update-submitting-status';
 export const SUBMIT_DETAILS = 'contact-us/submit-details';
 export const FINISH_REQUEST = 'contact-us/finish-request';
@@ -54,6 +56,26 @@ export const addAttachmentMetadata = metadata => ({
  */
 export const removeAttachmentMetadata = index => ({
   type: REMOVE_ATTACHMENT_METADATA,
+  payload: {
+    index
+  }
+});
+
+/**
+ * Add metadata for a screenshot
+ */
+export const addScreenshotMetadata = metadata => ({
+  type: ADD_SCREENSHOT_METADATA,
+  payload: {
+    metadata
+  }
+});
+
+/**
+ * Remove metadata for a screenshot
+ */
+export const removeScreenshotMetadata = index => ({
+  type: REMOVE_SCREENSHOT_METADATA,
   payload: {
     index
   }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsAttachments.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsAttachments.jsx
@@ -13,42 +13,42 @@ const ContactUsAttachments = ({
 }) => 
   <div className="contact-us-files">
     Attach up to three files (maximum {MAX_ATTACHMENT_SIZE_DESCRIPTION} per file).
-    <br />
-    <br />
-    {
-      validatedAttachmentMetadata.map(({ id, validity }, index) =>
-        <div key={id}>
-          <ValidatedInput
-            validity={validity}
-            onChange={event => changeFile(index, event.target.files)}
-            type="file"
-          />
-          <span className="remove-file">
-            <a href="#" onClick={e => {
-              e.preventDefault();
-              removeFile(index);
-            }}>
-              Remove file
-            </a>
-          </span>
-        </div>
-      )
-    }
+    <div className="contact-us-file-list">
+      {
+        validatedAttachmentMetadata.map(({ id, validity }, index) =>
+          <div key={id}>
+            <ValidatedInput
+              validity={validity}
+              onChange={event => changeFile(index, event.target.files)}
+              type="file"
+            />
+            <span className="remove-file">
+              <button type="button" className="btn" onClick={e => {
+                e.preventDefault();
+                removeFile(index);
+              }}>
+                Remove file
+              </button>
+            </span>
+          </div>
+        )
+      }
+    </div>
     {
       validatedAttachmentMetadata.length < 3 &&
       (
         <div className={validatedAttachmentMetadata.length === 0 
-          ? "" 
+          ? "add-file"
           : "add-another-file"
         } >
-          <a href="#" onClick={e => { 
+          <button type="button" className="btn" onClick={e => {
             e.preventDefault();
             addFile();
           }}>{
             validatedAttachmentMetadata.length === 0
               ? 'Add a file'
               : 'Add another file'
-          }</a>
+          }</button>
         </div>
       )
     }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsAttachments.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsAttachments.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ValidatedInput from '../../components/ValidatedInput';
 
+import { MAX_ATTACHMENT_SIZE_DESCRIPTION } from 'ebrc-client/selectors/ContactUsSelectors';
+
 import './ContactUsAttachments.scss';
 
 const ContactUsAttachments = ({ 
@@ -10,7 +12,7 @@ const ContactUsAttachments = ({
   validatedAttachmentMetadata
 }) => 
   <div className="contact-us-files">
-    Attach up to three screenshots (maximum 5Mb per file).
+    Attach up to three files (maximum {MAX_ATTACHMENT_SIZE_DESCRIPTION} per file).
     <br />
     <br />
     {

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsAttachments.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsAttachments.scss
@@ -1,6 +1,20 @@
 .contact-us-files {
-  .remove-file {
-    margin-left: 0.4em;
+  .contact-us-file-list {
+    margin-top: 0.5em;
+  }
+
+  input[type="file"] {
+    width: 27em;
+    margin-left: 0.5em;
+  }
+
+  .remove-file button.btn {
+    margin-left: 1em;
+  }
+
+  .add-file button.btn, .add-another-file button.btn {
+    margin-bottom: 1em;
+    margin-left: 0.5em;
   }
 
   .add-another-file {

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsForm.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsForm.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ContactUsAttachments from './ContactUsAttachments';
 import ContactUsFooter from './ContactUsFooter';
+import ContactUsScreenshots from './ContactUsScreenshots';
 import SupportFormField from '../SupportForm/SupportFormField';
 import ValidatedInput from '../ValidatedInput';
 import ValidatedTextArea from '../ValidatedTextArea';
@@ -17,6 +18,7 @@ const ContactUsForm = ({
   ccEmailsValidity,
   messageValidity,
   validatedAttachmentMetadata,
+  screenshotMetadata,
   updateSubject,
   updateReporterEmail,
   updateCcEmails,
@@ -24,6 +26,8 @@ const ContactUsForm = ({
   changeFile,
   addFile,
   removeFile,
+  addScreenshot,
+  removeScreenshot,
   submitDetails
 }) => (
   <form onSubmit={event => {
@@ -64,6 +68,16 @@ const ContactUsForm = ({
                 validity={ccEmailsValidity}
                 onChange={updateCcEmails} 
                 size={80} 
+              />
+            }
+          />
+          <SupportFormField
+            label="Screenshots:"
+            inputElement={
+              <ContactUsScreenshots
+                addScreenshot={addScreenshot}
+                removeScreenshot={removeScreenshot}
+                screenshotMetadata={screenshotMetadata}
               />
             }
           />

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsForm.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsForm.jsx
@@ -104,18 +104,7 @@ const ContactUsForm = ({
             />
             }
           />
-  {/*     <SupportFormField
-            label="Attachments:"
-            inputElement={
-              <ContactUsAttachments
-                changeFile={changeFile}
-                addFile={addFile}
-                removeFile={removeFile}
-                validatedAttachmentMetadata={validatedAttachmentMetadata}
-              />
-            }
-          />
-    */}       <ContactUsFooter 
+          <ContactUsFooter
             submitDisabled={submitDisabled}
             submissionFailed={submissionFailed}
             responseMessage={responseMessage}

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
@@ -1,0 +1,43 @@
+.ContactUsScreenshots {
+  &--ScreenshotPreviews {
+    margin-top: 0.4em;
+  }
+
+  &--ScreenshotPreview {
+    display: flex;
+    align-items: center;
+
+    margin-bottom: 1em;
+
+    > * {
+      flex: 0 0 auto;
+    }
+
+    img {
+      width: 15em;
+      border: 0.2em solid #aaaaaa;
+    }
+
+    button {
+      margin-left: 1em;
+    }
+  }
+
+  &--AddScreenshot {
+    margin-bottom: 1em;
+  }
+
+  button {
+    background: lightyellow;
+    color: #069;
+
+    border: 0.0625rem solid gray;
+    border-radius: 0.8em;
+    padding: 0.5em;
+
+    &:hover {
+      background: lightyellow;
+      text-decoration: underline;
+    }
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
@@ -18,26 +18,12 @@
       border: 0.2em solid #aaaaaa;
     }
 
-    button {
+    button.btn {
       margin-left: 1em;
     }
   }
 
   &--AddScreenshot {
     margin-bottom: 1em;
-  }
-
-  button {
-    background: lightyellow;
-    color: #069;
-
-    border: 0.0625rem solid gray;
-    border-radius: 0.8em;
-    padding: 0.5em;
-
-    &:hover {
-      background: lightyellow;
-      text-decoration: underline;
-    }
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
@@ -23,7 +23,8 @@
     }
   }
 
-  &--AddScreenshot {
+  &--AddScreenshot.btn {
     margin-bottom: 1em;
+    margin-left: 0.5em;
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.scss
@@ -1,6 +1,6 @@
 .ContactUsScreenshots {
   &--ScreenshotPreviews {
-    margin-top: 0.4em;
+    margin-top: 0.5em;
   }
 
   &--ScreenshotPreview {
@@ -14,7 +14,7 @@
     }
 
     img {
-      width: 15em;
+      width: 27em;
       border: 0.2em solid #aaaaaa;
     }
 

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 
-import { ImageUploadDialog } from './ImageUploadDialog';
+import { ImageUploadDialog } from 'ebrc-client/components/ContactUs/ImageUploadDialog';
+import { MAX_ATTACHMENT_SIZE_DESCRIPTION } from 'ebrc-client/selectors/ContactUsSelectors';
 
 import './ContactUsScreenshots.scss';
 
@@ -43,7 +44,7 @@ const ContactUsScreenshots = ({
           onClose={onImageUploadDialogClose}
         />
       }
-      Attach up to three screenshots from your clipboard (maximum 5Mb per image).
+      Attach up to three screenshots from your clipboard (maximum {MAX_ATTACHMENT_SIZE_DESCRIPTION} per image).
       <div className={cx('--ScreenshotPreviews')}>
         {
           screenshotMetadata.map(

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+
 import { ImageUploadDialog } from './ImageUploadDialog';
+
+import './ContactUsScreenshots.scss';
+
+const cx = makeClassNameHelper('ContactUsScreenshots');
 
 interface Props {
   addScreenshot: (file: File) => void;
@@ -29,7 +35,7 @@ const ContactUsScreenshots = ({
   }, []);
 
   return (
-    <div className="contact-us-files">
+    <div className={cx()}>
       {
         imageUploadDialogOpen &&
         <ImageUploadDialog
@@ -38,22 +44,24 @@ const ContactUsScreenshots = ({
         />
       }
       Attach up to three screenshots from your clipboard (maximum 5Mb per image).
-      {
-        screenshotMetadata.map(
-          (screenshotMetadatum, i) => (
-            <ScreenshotPreview
-              key={screenshotMetadatum.id}
-              onRemoveScreenshot={() => {
-                removeScreenshot(i);
-              }}
-              imageFile={screenshotMetadatum.file}
-            />
+      <div className={cx('--ScreenshotPreviews')}>
+        {
+          screenshotMetadata.map(
+            (screenshotMetadatum, i) => (
+              <ScreenshotPreview
+                key={screenshotMetadatum.id}
+                onRemoveScreenshot={() => {
+                  removeScreenshot(i);
+                }}
+                imageFile={screenshotMetadatum.file}
+              />
+            )
           )
-        )
-      }
+        }
+      </div>
       {
         screenshotMetadata.length < 3 &&
-        <button type="button" onClick={onImageUploadDialogOpen}>{
+        <button className={cx('--AddScreenshot')} type="button" onClick={onImageUploadDialogOpen}>{
           screenshotMetadata.length === 0
             ? 'Add a screenshot'
             : 'Add another screenshot'
@@ -82,7 +90,7 @@ function ScreenshotPreview({ imageFile, onRemoveScreenshot }: ScreenshotProps) {
   }, [ imageUrl ] );
 
   return (
-    <div>
+    <div className={cx('--ScreenshotPreview')}>
       <img src={imageUrl} />
       <button type="button" onClick={onRemoveScreenshot}>Remove this screenshot</button>
     </div>

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
@@ -62,7 +62,7 @@ const ContactUsScreenshots = ({
       </div>
       {
         screenshotMetadata.length < 3 &&
-        <button className={cx('--AddScreenshot')} type="button" onClick={onImageUploadDialogOpen}>{
+        <button className={`${cx('--AddScreenshot')} btn`} type="button" onClick={onImageUploadDialogOpen}>{
           screenshotMetadata.length === 0
             ? 'Add a screenshot'
             : 'Add another screenshot'
@@ -93,7 +93,7 @@ function ScreenshotPreview({ imageFile, onRemoveScreenshot }: ScreenshotProps) {
   return (
     <div className={cx('--ScreenshotPreview')}>
       <img src={imageUrl} />
-      <button type="button" onClick={onRemoveScreenshot}>Remove this screenshot</button>
+      <button className="btn" type="button" onClick={onRemoveScreenshot}>Remove this screenshot</button>
     </div>
   );
 }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsScreenshots.tsx
@@ -1,0 +1,92 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { ImageUploadDialog } from './ImageUploadDialog';
+
+interface Props {
+  addScreenshot: (file: File) => void;
+  removeScreenshot: (index: number) => void;
+  screenshotMetadata: { id: number, file: File }[];
+}
+
+const ContactUsScreenshots = ({
+  addScreenshot,
+  removeScreenshot,
+  screenshotMetadata
+}: Props) => {
+  const [ imageUploadDialogOpen, setImageUploadDialogOpen ] = useState(false);
+
+  const onImageUploadDialogOpen = useCallback(() => {
+    setImageUploadDialogOpen(true);
+  }, []);
+
+  const onImageUploadDialogSubmit = useCallback((file: File) => {
+    setImageUploadDialogOpen(false);
+    addScreenshot(file);
+  }, [ addScreenshot ]);
+
+  const onImageUploadDialogClose = useCallback(() => {
+    setImageUploadDialogOpen(false);
+  }, []);
+
+  return (
+    <div className="contact-us-files">
+      {
+        imageUploadDialogOpen &&
+        <ImageUploadDialog
+          onSubmit={onImageUploadDialogSubmit}
+          onClose={onImageUploadDialogClose}
+        />
+      }
+      Attach up to three screenshots from your clipboard (maximum 5Mb per image).
+      {
+        screenshotMetadata.map(
+          (screenshotMetadatum, i) => (
+            <ScreenshotPreview
+              key={screenshotMetadatum.id}
+              onRemoveScreenshot={() => {
+                removeScreenshot(i);
+              }}
+              imageFile={screenshotMetadatum.file}
+            />
+          )
+        )
+      }
+      {
+        screenshotMetadata.length < 3 &&
+        <button type="button" onClick={onImageUploadDialogOpen}>{
+          screenshotMetadata.length === 0
+            ? 'Add a screenshot'
+            : 'Add another screenshot'
+        }</button>
+      }
+    </div>
+  );
+}
+
+interface ScreenshotProps {
+  imageFile: File;
+  onRemoveScreenshot: () => void;
+}
+
+function ScreenshotPreview({ imageFile, onRemoveScreenshot }: ScreenshotProps) {
+  const [ imageUrl, setImageUrl ] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setImageUrl(URL.createObjectURL(imageFile));
+  }, [ imageFile ]);
+
+  useEffect(() => () => {
+    if (imageUrl != null) {
+      URL.revokeObjectURL(imageUrl);
+    }
+  }, [ imageUrl ] );
+
+  return (
+    <div>
+      <img src={imageUrl} />
+      <button type="button" onClick={onRemoveScreenshot}>Remove this screenshot</button>
+    </div>
+  );
+}
+
+export default ContactUsScreenshots;

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsSubmission.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ContactUsSubmission.jsx
@@ -19,10 +19,13 @@ const ContactUsSubmission = ({
   changeFile,
   addFile,
   removeFile,
+  addScreenshot,
+  removeScreenshot,
   reporterEmailValidity,
   ccEmailsValidity,
   messageValidity,
   validatedAttachmentMetadata,
+  screenshotMetadata,
   submitDetails,
   specialInstructions
 }) => (
@@ -46,10 +49,13 @@ const ContactUsSubmission = ({
         changeFile={changeFile}
         addFile={addFile}
         removeFile={removeFile}
+        addScreenshot={addScreenshot}
+        removeScreenshot={removeScreenshot}
         reporterEmailValidity={reporterEmailValidity}
         ccEmailsValidity={ccEmailsValidity}
         messageValidity={messageValidity}
         validatedAttachmentMetadata={validatedAttachmentMetadata}
+        screenshotMetadata={screenshotMetadata}
         submitDetails={submitDetails}
       />
     </SupportFormBody>

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
@@ -1,6 +1,22 @@
 .ImageUploadDialog {
-  &--Content {
-    
+  .wdk-DialogHeader {
+    background: white;
+  }
+
+  .wdk-DialogContent {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .btn {
+    font-size: 1.4em;
+
+    margin-left: 0.75em;
+    margin-right: 0.75em;
+  }
+
+  &--Instructions {
+    font-size: 1.5em;
   }
 
   &--PasteZone {
@@ -23,5 +39,9 @@
       max-height: 80vh;
       max-width: 85vw;
     }
+  }
+
+  &--Footer {
+    margin-top: 1em;
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
@@ -1,0 +1,24 @@
+.ImageUploadDialog {
+  &--Content {
+    
+  }
+
+  &--PasteZone {
+    height: 80vh;
+    width: 85vw;
+    box-sizing: content-box;
+
+    border: 0.5em solid #aaaaaa;
+    padding: 0.5em;
+
+    background-color: #dddddd;
+  }
+
+  .ReactCrop {
+    &__image {
+      max-height: 80vh;
+      max-width: 85vw;
+      object-fit: 'scale-down';
+    }
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
@@ -22,7 +22,6 @@
     &__image {
       max-height: 80vh;
       max-width: 85vw;
-      object-fit: 'scale-down';
     }
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
@@ -36,7 +36,7 @@
 
   .ReactCrop {
     &__image {
-      max-height: 80vh;
+      max-height: calc(80vh - 5em);
       max-width: 85vw;
     }
   }

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
@@ -4,6 +4,10 @@
   }
 
   &--PasteZone {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     height: 80vh;
     width: 85vw;
     box-sizing: content-box;

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -4,6 +4,11 @@ import ReactCrop, { Crop } from 'react-image-crop';
 import { Dialog } from 'wdk-client/Components';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 
+import {
+  MAX_ATTACHMENT_SIZE,
+  MAX_ATTACHMENT_SIZE_DESCRIPTION
+} from 'ebrc-client/selectors/ContactUsSelectors';
+
 import 'react-image-crop/lib/ReactCrop.scss';
 
 import './ImageUploadDialog.scss';
@@ -140,6 +145,11 @@ function submitCroppedImg(
     crop.height == null ||
     crop.width == null
   ) {
+    if (uncroppedFile.size > MAX_ATTACHMENT_SIZE) {
+      alert(`Please submit a screenshot which is under ${MAX_ATTACHMENT_SIZE_DESCRIPTION}`);
+      return;
+    }
+
     onSubmit(uncroppedFile);
     return;
   }
@@ -170,6 +180,11 @@ function submitCroppedImg(
   canvas.toBlob(blob => {
     if (blob == null) {
       throw new Error('Could not write the cropped screenshot canvas to a file');
+    }
+
+    if (blob.size > MAX_ATTACHMENT_SIZE) {
+      alert(`Please submit a cropping which is under ${MAX_ATTACHMENT_SIZE_DESCRIPTION}`);
+      return;
     }
 
     const croppedFile = new File([ blob ], uncroppedFile.name);

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -58,7 +58,7 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
       <div className={cx('--PasteZone')}>
         {
           imageUrl == null
-            ? <p className={cx('--Instructions')}>Paste a screenshot into this window using Ctrl/Command + V</p>
+            ? <p className={cx('--Instructions')}>Paste a screenshot into this window using Ctrl/Cmd + V</p>
             : <ReactCrop
                 onImageLoaded={onPreviewImageLoaded}
                 src={imageUrl}

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -48,22 +48,23 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
   }, [ fullImageRef.current, previewImageRef.current, crop, onSubmit, imageFile ]);
 
   return (
-    <Dialog open modal className={cx()} onClose={onClose}>
+    <Dialog open modal className={cx()} title="Add A Screenshot From Your Clipboard" onClose={onClose}>
       <div className={cx('--PasteZone')}>
         {
-          imageUrl &&
-          <ReactCrop
-            onImageLoaded={onPreviewImageLoaded}
-            src={imageUrl}
-            crop={crop}
-            onChange={setCrop}
-          />
+          imageUrl == null
+            ? <p className={cx('--Instructions')}>Paste a screenshot into this window using Ctrl/Command + V</p>
+            : <ReactCrop
+                onImageLoaded={onPreviewImageLoaded}
+                src={imageUrl}
+                crop={crop}
+                onChange={setCrop}
+              />
         }
         <img ref={fullImageRef} src={imageUrl} style={{ display: 'none' }} />
       </div>
       <div className={cx('--Footer')}>
-        <button disabled={imageFile == null} onClick={onClickOk} type="button">OK</button>
-        <button onClick={onClose} type="button">Cancel</button>
+        <button className="btn" disabled={imageFile == null} onClick={onClickOk} type="button">OK</button>
+        <button className="btn" onClick={onClose} type="button">Cancel</button>
       </div>
     </Dialog>
   );

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -87,13 +87,16 @@ function useImageFromClipboard() {
       const pastedItems = [...event.clipboardData.items];
       const pastedImageItem = pastedItems.find(({ type }) => type.startsWith('image'));
 
-      if (pastedImageItem != null) {
-        const pastedImageFile = pastedImageItem.getAsFile();
+      if (pastedImageItem == null) {
+        alert("No image was found in your clipboard. You can add a screenshot to your clipboard using your computer's 'Print Screen' functionality.");
+        return;
+      }
 
-        if (pastedImageFile != null) {
-          setPastedImage(pastedImageFile);
-          setPastedImageUrl(URL.createObjectURL(pastedImageFile));
-        }
+      const pastedImageFile = pastedImageItem.getAsFile();
+
+      if (pastedImageFile != null) {
+        setPastedImage(pastedImageFile);
+        setPastedImageUrl(URL.createObjectURL(pastedImageFile));
       }
     }
   }, []);

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -1,7 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import ReactCrop from 'react-image-crop';
 
 import { Dialog } from 'wdk-client/Components';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+
+import 'react-image-crop/lib/ReactCrop.scss';
+
+import './ImageUploadDialog.scss';
 
 const cx = makeClassNameHelper('ImageUploadDialog');
 
@@ -13,13 +18,41 @@ interface Props {
 export function ImageUploadDialog({ onSubmit, onClose }: Props) {
   const { imageFile, imageUrl } = useImageFromClipboard();
 
+  const initialCrop = { unit: '%', x: 25, y: 25, height: 50, width: 50, aspect: undefined } as const;
+  const [ crop, setCrop ] = useState<ReactCrop.Crop | undefined>(initialCrop);
+
+  const resetCrop = useCallback(() => {
+    setCrop(initialCrop);
+  }, []);
+
+  useEffect(() => {
+    resetCrop();
+  }, [ imageFile, resetCrop ]);
+
+  useEffect(() => {
+    window.addEventListener('resize', resetCrop);
+
+    return () => {
+      window.removeEventListener('resize', resetCrop);
+    };
+  }, [ resetCrop ]);
+
   const onClickOk = useCallback(() => {
     onSubmit(imageFile as File);
   }, [ onSubmit, imageFile ]);
 
   return (
     <Dialog open modal className={cx()} onClose={onClose}>
-      <img className={cx('--Image')} src={imageUrl} />
+      <div className={cx('--PasteZone')}>
+        {
+          imageUrl &&
+          <ReactCrop
+            src={imageUrl}
+            crop={crop}
+            onChange={setCrop}
+          />
+        }
+      </div>
       <div className={cx('--Footer')}>
         <button disabled={imageFile == null} onClick={onClickOk} type="button">OK</button>
         <button onClick={onClose} type="button">Cancel</button>

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -37,9 +37,11 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
 
   useEffect(() => {
     window.addEventListener('resize', resetCrop);
+    window.addEventListener('zoom', resetCrop);
 
     return () => {
       window.removeEventListener('resize', resetCrop);
+      window.removeEventListener('zoom', resetCrop);
     };
   }, [ resetCrop ]);
 

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Dialog } from 'wdk-client/Components';
+import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+
+const cx = makeClassNameHelper('ImageUploadDialog');
+
+interface Props {
+  onSubmit: (file: File) => void;
+  onClose: () => void;
+}
+
+export function ImageUploadDialog({ onSubmit, onClose }: Props) {
+  const { imageFile, imageUrl } = useImageFromClipboard();
+
+  const onClickOk = useCallback(() => {
+    onSubmit(imageFile as File);
+  }, [ onSubmit, imageFile ]);
+
+  return (
+    <Dialog open modal className={cx()} onClose={onClose}>
+      <img className={cx('--Image')} src={imageUrl} />
+      <div className={cx('--Footer')}>
+        <button disabled={imageFile == null} onClick={onClickOk} type="button">OK</button>
+        <button onClick={onClose} type="button">Cancel</button>
+      </div>
+    </Dialog>
+  );
+}
+
+function useImageFromClipboard() {
+  const [ pastedImage, setPastedImage ] = useState<File | undefined>(undefined);
+  const [ pastedImageUrl, setPastedImageUrl ] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    window.addEventListener('paste', handlePaste, false);
+
+    return () => {
+      window.removeEventListener('paste', handlePaste, false);
+    };
+
+    function handlePaste(event: Event) {
+      if (
+        event instanceof ClipboardEvent &&
+        event.clipboardData?.items != null
+      ) {
+        const pastedItems = [...event.clipboardData.items];
+        const pastedImageItem = pastedItems.find(({ type }) => type.startsWith('image'));
+
+        if (pastedImageItem != null) {
+          const pastedImageFile = pastedImageItem.getAsFile();
+
+          if (pastedImageFile != null) {
+            setPastedImage(pastedImageFile);
+            setPastedImageUrl(URL.createObjectURL(pastedImageFile));
+          }
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => () => {
+    if (pastedImageUrl != null) {
+      URL.revokeObjectURL(pastedImageUrl);
+    }
+  }, [ pastedImageUrl ]);
+
+  return {
+    imageFile: pastedImage,
+    imageUrl: pastedImageUrl
+  };
+}

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import ReactCrop from 'react-image-crop';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import ReactCrop, { Crop } from 'react-image-crop';
 
 import { Dialog } from 'wdk-client/Components';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
@@ -19,7 +19,9 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
   const { imageFile, imageUrl } = useImageFromClipboard();
 
   const initialCrop = { unit: '%', x: 25, y: 25, height: 50, width: 50, aspect: undefined } as const;
-  const [ crop, setCrop ] = useState<ReactCrop.Crop | undefined>(initialCrop);
+  const [ crop, setCrop ] = useState<Crop | undefined>(initialCrop);
+  const fullImageRef = useRef<HTMLImageElement>(null);
+  const previewImageRef = useRef<HTMLImageElement>();
 
   const resetCrop = useCallback(() => {
     setCrop(initialCrop);
@@ -37,9 +39,13 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
     };
   }, [ resetCrop ]);
 
+  const onPreviewImageLoaded = useCallback((previewImage: HTMLImageElement) => {
+    previewImageRef.current = previewImage;
+  }, [ previewImageRef.current ]);
+
   const onClickOk = useCallback(() => {
-    onSubmit(imageFile as File);
-  }, [ onSubmit, imageFile ]);
+    submitCroppedImg(fullImageRef.current, previewImageRef.current, crop, onSubmit, imageFile);
+  }, [ fullImageRef.current, previewImageRef.current, crop, onSubmit, imageFile ]);
 
   return (
     <Dialog open modal className={cx()} onClose={onClose}>
@@ -47,11 +53,13 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
         {
           imageUrl &&
           <ReactCrop
+            onImageLoaded={onPreviewImageLoaded}
             src={imageUrl}
             crop={crop}
             onChange={setCrop}
           />
         }
+        <img ref={fullImageRef} src={imageUrl} style={{ display: 'none' }} />
       </div>
       <div className={cx('--Footer')}>
         <button disabled={imageFile == null} onClick={onClickOk} type="button">OK</button>
@@ -65,31 +73,31 @@ function useImageFromClipboard() {
   const [ pastedImage, setPastedImage ] = useState<File | undefined>(undefined);
   const [ pastedImageUrl, setPastedImageUrl ] = useState<string | undefined>(undefined);
 
+  const handlePaste = useCallback((event: Event) => {
+    if (
+      event instanceof ClipboardEvent &&
+      event.clipboardData?.items != null
+    ) {
+      const pastedItems = [...event.clipboardData.items];
+      const pastedImageItem = pastedItems.find(({ type }) => type.startsWith('image'));
+
+      if (pastedImageItem != null) {
+        const pastedImageFile = pastedImageItem.getAsFile();
+
+        if (pastedImageFile != null) {
+          setPastedImage(pastedImageFile);
+          setPastedImageUrl(URL.createObjectURL(pastedImageFile));
+        }
+      }
+    }
+  }, []);
+
   useEffect(() => {
     window.addEventListener('paste', handlePaste, false);
 
     return () => {
       window.removeEventListener('paste', handlePaste, false);
     };
-
-    function handlePaste(event: Event) {
-      if (
-        event instanceof ClipboardEvent &&
-        event.clipboardData?.items != null
-      ) {
-        const pastedItems = [...event.clipboardData.items];
-        const pastedImageItem = pastedItems.find(({ type }) => type.startsWith('image'));
-
-        if (pastedImageItem != null) {
-          const pastedImageFile = pastedImageItem.getAsFile();
-
-          if (pastedImageFile != null) {
-            setPastedImage(pastedImageFile);
-            setPastedImageUrl(URL.createObjectURL(pastedImageFile));
-          }
-        }
-      }
-    }
   }, []);
 
   useEffect(() => () => {
@@ -102,4 +110,69 @@ function useImageFromClipboard() {
     imageFile: pastedImage,
     imageUrl: pastedImageUrl
   };
+}
+
+// Adaptation of https://github.com/DominicTobias/react-image-crop#what-about-showing-the-crop-on-the-client
+function submitCroppedImg(
+  fullImage: HTMLImageElement | null,
+  previewImage: HTMLImageElement | undefined,
+  crop: Crop | undefined,
+  onSubmit: (file: File) => void,
+  uncroppedFile: File | undefined
+) {
+  if (fullImage == null) {
+    throw new Error('Could not obtain the image containing the pasted screenshot.');
+  }
+
+  if (previewImage == null) {
+    throw new Error('Could not obtain preview image for the pasted screenshot.');
+  }
+
+  if (uncroppedFile == null) {
+    throw new Error('Could not retrieve the file with the pasted screenshot.');
+  }
+
+  if (
+    crop == null ||
+    crop.x == null ||
+    crop.y == null ||
+    crop.height == null ||
+    crop.width == null
+  ) {
+    onSubmit(uncroppedFile);
+    return;
+  }
+
+  const canvas = document.createElement('canvas');
+  const scaleX = fullImage.naturalWidth / previewImage.width;
+  const scaleY = fullImage.naturalHeight / previewImage.height;
+  canvas.width = crop.width * scaleX / window.devicePixelRatio;
+  canvas.height = crop.height * scaleY / window.devicePixelRatio;
+  const ctx = canvas.getContext('2d');
+
+  if (ctx == null) {
+    throw new Error('Could not initialize canvas for cropped screenshot.');
+  }
+
+  ctx.drawImage(
+    fullImage,
+    crop.x * scaleX,
+    crop.y * scaleY,
+    crop.width * scaleX,
+    crop.height * scaleY,
+    0,
+    0,
+    crop.width * scaleX / window.devicePixelRatio,
+    crop.height * scaleY / window.devicePixelRatio
+  );
+
+  canvas.toBlob(blob => {
+    if (blob == null) {
+      throw new Error('Could not write the cropped screenshot canvas to a file');
+    }
+
+    const croppedFile = new File([ blob ], uncroppedFile.name);
+
+    onSubmit(croppedFile);
+  }, uncroppedFile.type, 1);
 }

--- a/Site/webapp/wdkCustomization/js/client/components/SupportForm/SupportFormBase.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/SupportForm/SupportFormBase.scss
@@ -15,17 +15,6 @@
       align-self: center;
       font-size: 120%;
 
-      div.contact-us-files {
-        margin-bottom: 1em;
-      }
-
-      div.contact-us-files a {
-        background-color: lightyellow;
-        padding: 0.5em;
-        border-radius: 0.8em;
-        border: 1px solid grey;
-      }
-
       h4 {
         margin: 1em 0em;
       }

--- a/Site/webapp/wdkCustomization/js/client/controllers/ContactUsController.jsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/ContactUsController.jsx
@@ -10,6 +10,8 @@ import {
   changeAttachmentMetadata,
   addAttachmentMetadata,
   removeAttachmentMetadata,
+  addScreenshotMetadata,
+  removeScreenshotMetadata,
   submitDetails  
 } from  '../actioncreators/ContactUsActionCreators';
 
@@ -29,7 +31,8 @@ import {
   messageValidity,
   reporterEmailValidity,
   ccEmailsValidity,
-  validatedAttachmentMetadata
+  validatedAttachmentMetadata,
+  screenshotMetadata
 } from '../selectors/ContactUsSelectors';
 
 class ContactUsView extends PageController {
@@ -70,7 +73,8 @@ class ContactUsView extends PageController {
       reporterEmailValidity,
       ccEmailsValidity,
       messageValidity,
-      validatedAttachmentMetadata
+      validatedAttachmentMetadata,
+      screenshotMetadata
     } = this.props.stateProps;
 
     const {
@@ -81,6 +85,8 @@ class ContactUsView extends PageController {
       changeFile,
       addFile,
       removeFile,
+      addScreenshot,
+      removeScreenshot,
       submitDetails
     } = this.props.dispatchProps;
 
@@ -109,10 +115,13 @@ class ContactUsView extends PageController {
                 changeFile={changeFile}
                 addFile={addFile}
                 removeFile={removeFile}
+                addScreenshot={addScreenshot}
+                removeScreenshot={removeScreenshot}
                 reporterEmailValidity={reporterEmailValidity}
                 ccEmailsValidity={ccEmailsValidity}
                 messageValidity={messageValidity}
                 validatedAttachmentMetadata={validatedAttachmentMetadata}
+                screenshotMetadata={screenshotMetadata}
                 submitDetails={submitDetails}
                 specialInstructions={this.props.specialInstructions}
               />
@@ -141,7 +150,8 @@ const mapStateToProps = ({
   reporterEmailValidity: reporterEmailValidity(contactUsState),
   ccEmailsValidity: ccEmailsValidity(contactUsState),
   messageValidity: messageValidity(contactUsState),
-  validatedAttachmentMetadata: validatedAttachmentMetadata(contactUsState)
+  validatedAttachmentMetadata: validatedAttachmentMetadata(contactUsState),
+  screenshotMetadata: screenshotMetadata(contactUsState)
 });
 
 const mapDispatchToProps = {
@@ -157,6 +167,8 @@ const mapDispatchToProps = {
   },
   addFile: () => addAttachmentMetadata({}),
   removeFile: index => removeAttachmentMetadata(index),
+  addScreenshot: file => addScreenshotMetadata({ file }),
+  removeScreenshot: index => removeScreenshotMetadata(index),
   submitDetails
 };
 

--- a/Site/webapp/wdkCustomization/js/client/selectors/ContactUsSelectors.js
+++ b/Site/webapp/wdkCustomization/js/client/selectors/ContactUsSelectors.js
@@ -1,5 +1,6 @@
 import { 
   compose,
+  concat,
   filter, 
   isEqual, 
   length,
@@ -30,6 +31,7 @@ export const ccEmailsValue = propSelectorFactory('ccEmails');
 export const messageValue = propSelectorFactory('message');
 export const contextValue = propSelectorFactory('context');
 export const attachmentMetadata = propSelectorFactory('attachmentMetadata');
+export const screenshotMetadata = propSelectorFactory('screenshotMetadata');
 
 export const submitDisabled = submittingStatus;
 
@@ -83,7 +85,11 @@ export const ccEmailsValidity = createSelector(
 
 export const files = createSelector(
   attachmentMetadata,
-  map('file')
+  screenshotMetadata,
+  compose(
+    map('file'),
+    concat
+  )
 );
 
 export const validatedAttachmentMetadata = createSelector(

--- a/Site/webapp/wdkCustomization/js/client/selectors/ContactUsSelectors.js
+++ b/Site/webapp/wdkCustomization/js/client/selectors/ContactUsSelectors.js
@@ -18,7 +18,8 @@ import {
 // Source: emailregex.com (which implements the RFC 5322 standard)
 const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-const MAX_ATTACHMENT_SIZE = 5000000;
+export const MAX_ATTACHMENT_SIZE = 5000000;
+export const MAX_ATTACHMENT_SIZE_DESCRIPTION = '5Mb';
 
 const propSelectorFactory = prop => state => state[prop];
 
@@ -101,7 +102,7 @@ const validateMetadatum = metadatum => {
   if (!metadatum.file) {
     return addValidityToAttachmentMetadatum(metadatum, 'Please choose a file to upload.')
   } else if (metadatum.file.size > MAX_ATTACHMENT_SIZE) {
-    return addValidityToAttachmentMetadatum(metadatum, 'Please choose a file which is under 5 Mb.');
+    return addValidityToAttachmentMetadatum(metadatum, `Please choose a file which is under ${MAX_ATTACHMENT_SIZE_DESCRIPTION}.`);
   } else {
     return addValidityToAttachmentMetadatum(metadatum, '');
   }    

--- a/Site/webapp/wdkCustomization/js/client/store-modules/ContactUsStoreModule.js
+++ b/Site/webapp/wdkCustomization/js/client/store-modules/ContactUsStoreModule.js
@@ -19,6 +19,8 @@ import {
   CHANGE_ATTACHMENT_METADATA,
   ADD_ATTACHMENT_METADATA,
   REMOVE_ATTACHMENT_METADATA,
+  ADD_SCREENSHOT_METADATA,
+  REMOVE_SCREENSHOT_METADATA,
   SUBMIT_DETAILS,
   FINISH_REQUEST,
   UPDATE_SUBMITTING_STATUS,
@@ -45,10 +47,12 @@ const initialState = {
   message: '',
   context: '',
   attachmentMetadata: [],
+  screenshotMetadata: [],
   submittingStatus: false,
   submissionStatus: SUBMISSION_PENDING,
   responseMessage: '',
-  nextAttachmentId: 0
+  nextAttachmentId: 0,
+  nextScreenshotId: 0
 };
 
 export function reduce(state = initialState, { type, payload }) {
@@ -115,6 +119,28 @@ export function reduce(state = initialState, { type, payload }) {
         attachmentMetadata: [
           ...state.attachmentMetadata.slice(0, payload.index),
           ...state.attachmentMetadata.slice(payload.index + 1)
+        ]
+      };
+
+    case ADD_SCREENSHOT_METADATA:
+      return {
+        ...state,
+        screenshotMetadata: [
+          ...state.screenshotMetadata,
+          {
+            ...payload.metadata,
+            id: state.nextScreenshotId
+          }
+        ],
+        nextScreenshotId: state.nextScreenshotId + 1
+      };
+
+    case REMOVE_SCREENSHOT_METADATA:
+      return {
+        ...state,
+        screenshotMetadata: [
+          ...state.screenshotMetadata.slice(0, payload.index),
+          ...state.screenshotMetadata.slice(payload.index + 1)
         ]
       };
 

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-image-crop@^8.1.2":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-image-crop/-/react-image-crop-8.1.2.tgz#9c16d6b0b577a63a854a1a895180cc76800e2988"
+  integrity sha512-K6mbw1Bj/CeePnRa78E3v3gIn/EeqlCof5IVU9IPLdzMjOsf+ccn3Qv/vagsH/6eANGgoDz4hG41eJ2kggiuuw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.9.41"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.41.tgz#925137ee4d2ff406a0ecf29e8e9237390844002e"
+  integrity sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -124,6 +144,11 @@ charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -156,6 +181,11 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+core-js@^3.4.2:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -164,6 +194,11 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+
+csstype@^2.2.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
+  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
 
 cubic2quad@^1.0.0:
   version "1.1.1"
@@ -400,6 +435,11 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -434,6 +474,13 @@ lodash@^4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 md5@^2.2.1:
   version "2.2.1"
@@ -541,7 +588,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -596,6 +643,15 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -615,6 +671,20 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+react-image-crop@^8.6.4:
+  version "8.6.4"
+  resolved "https://registry.yarnpkg.com/react-image-crop/-/react-image-crop-8.6.4.tgz#51289c22baf7d116575102e885f879af71376388"
+  integrity sha512-5buyhUg9slzW+QGvN2dbpGSI1VqPxxmfEwe19TZXUB7LjW5+ljZOnrTSsteIzeBqmz6ngVucc8l+OrwgcDOSNg==
+  dependencies:
+    clsx "^1.0.4"
+    core-js "^3.4.2"
+    prop-types "^15.7.2"
+
+react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 readable-stream@^1.0.33:
   version "1.1.14"


### PR DESCRIPTION
This PR adds a new "Screenshots" field to our Contact Us form, which allows users to upload up to 3 images from their clipboard.

In addition:
* Uploaded images can be cropped before submission
* A scaled preview of each screenshot is displayed on the Contact Us form

Some cleanup to the existing Contact Us styling and code is also provided. (For example, all buttons are now styled using our standard "btn" styling, and various anchor tags from the "Attachments" field have now been replaced with buttons.)

This work is running on https://jtlong.plasmodb.org/plasmo.jtlong/app/contact-us