### PR TITLE
Remove redundant image cropping functionality

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -5,11 +5,9 @@
   "repository": {},
   "license": "MIT",
   "dependencies": {
-    "@types/react-image-crop": "^8.1.2",
     "custom-event-polyfill": "^1.0.7",
     "icon-font-generator": "^2.1.8",
     "md5": "^2.2.1",
-    "react-image-crop": "^8.6.4",
     "whatwg-fetch": "^3.0.0"
   },
   "scripts": {

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.scss
@@ -34,11 +34,9 @@
     background-color: #dddddd;
   }
 
-  .ReactCrop {
-    &__image {
-      max-height: calc(80vh - 5em);
-      max-width: 85vw;
-    }
+  img {
+    max-height: calc(80vh - 5em);
+    max-width: 85vw;
   }
 
   &--Footer {

--- a/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/ContactUs/ImageUploadDialog.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import ReactCrop, { Crop } from 'react-image-crop';
 
 import { Dialog } from 'wdk-client/Components';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
@@ -8,8 +7,6 @@ import {
   MAX_ATTACHMENT_SIZE,
   MAX_ATTACHMENT_SIZE_DESCRIPTION
 } from 'ebrc-client/selectors/ContactUsSelectors';
-
-import 'react-image-crop/lib/ReactCrop.scss';
 
 import './ImageUploadDialog.scss';
 
@@ -23,35 +20,15 @@ interface Props {
 export function ImageUploadDialog({ onSubmit, onClose }: Props) {
   const { imageFile, imageUrl } = useImageFromClipboard();
 
-  const initialCrop = { unit: '%', x: 25, y: 25, height: 50, width: 50, aspect: undefined } as const;
-  const [ crop, setCrop ] = useState<Crop | undefined>(initialCrop);
-  const previewImageRef = useRef<HTMLImageElement>();
-
-  const resetCrop = useCallback(() => {
-    setCrop(initialCrop);
-  }, []);
-
-  useEffect(() => {
-    resetCrop();
-  }, [ imageFile, resetCrop ]);
-
-  useEffect(() => {
-    window.addEventListener('resize', resetCrop);
-    window.addEventListener('zoom', resetCrop);
-
-    return () => {
-      window.removeEventListener('resize', resetCrop);
-      window.removeEventListener('zoom', resetCrop);
-    };
-  }, [ resetCrop ]);
-
-  const onPreviewImageLoaded = useCallback((previewImage: HTMLImageElement) => {
-    previewImageRef.current = previewImage;
-  }, [ previewImageRef.current ]);
-
   const onClickOk = useCallback(() => {
-    submitCroppedImg(previewImageRef.current, crop, onSubmit, imageFile);
-  }, [ previewImageRef.current, crop, onSubmit, imageFile ]);
+    if (imageFile != null) {
+      if (imageFile.size > MAX_ATTACHMENT_SIZE) {
+        alert(`Please upload a screenshot which is no larger than ${MAX_ATTACHMENT_SIZE_DESCRIPTION}`);
+      } else {
+        onSubmit(imageFile);
+      }
+    }
+  }, [ onSubmit, imageFile ]);
 
   return (
     <Dialog open modal className={cx()} title="Add A Screenshot From Your Clipboard" onClose={onClose}>
@@ -59,12 +36,7 @@ export function ImageUploadDialog({ onSubmit, onClose }: Props) {
         {
           imageUrl == null
             ? <p className={cx('--Instructions')}>Paste a screenshot into this window using Ctrl/Cmd + V</p>
-            : <ReactCrop
-                onImageLoaded={onPreviewImageLoaded}
-                src={imageUrl}
-                crop={crop}
-                onChange={setCrop}
-              />
+            : <img src={imageUrl} />
         }
       </div>
       <div className={cx('--Footer')}>
@@ -119,76 +91,4 @@ function useImageFromClipboard() {
     imageFile: pastedImage,
     imageUrl: pastedImageUrl
   };
-}
-
-// Adaptation of https://github.com/DominicTobias/react-image-crop#what-about-showing-the-crop-on-the-client
-function submitCroppedImg(
-  previewImage: HTMLImageElement | undefined,
-  crop: Crop | undefined,
-  onSubmit: (file: File) => void,
-  uncroppedFile: File | undefined
-) {
-  if (previewImage == null) {
-    throw new Error('Could not obtain preview image for the pasted screenshot.');
-  }
-
-  if (uncroppedFile == null) {
-    throw new Error('Could not retrieve the file with the pasted screenshot.');
-  }
-
-  if (
-    crop == null ||
-    crop.x == null ||
-    crop.y == null ||
-    crop.height == null ||
-    crop.width == null
-  ) {
-    if (uncroppedFile.size > MAX_ATTACHMENT_SIZE) {
-      alert(`Please submit a screenshot which is under ${MAX_ATTACHMENT_SIZE_DESCRIPTION}`);
-      return;
-    }
-
-    onSubmit(uncroppedFile);
-    return;
-  }
-
-  const devicePixelRatio = window.devicePixelRatio || 1;
-
-  const canvas = document.createElement('canvas');
-  const scaleX = previewImage.naturalWidth / previewImage.width;
-  const scaleY = previewImage.naturalHeight / previewImage.height;
-  canvas.width = crop.width * scaleX / devicePixelRatio;
-  canvas.height = crop.height * scaleY / devicePixelRatio;
-  const ctx = canvas.getContext('2d');
-
-  if (ctx == null) {
-    throw new Error('Could not initialize canvas for cropped screenshot.');
-  }
-
-  ctx.drawImage(
-    previewImage,
-    crop.x * scaleX,
-    crop.y * scaleY,
-    crop.width * scaleX,
-    crop.height * scaleY,
-    0,
-    0,
-    crop.width * scaleX / devicePixelRatio,
-    crop.height * scaleY / devicePixelRatio
-  );
-
-  canvas.toBlob(blob => {
-    if (blob == null) {
-      throw new Error('Could not write the cropped screenshot canvas to a file');
-    }
-
-    if (blob.size > MAX_ATTACHMENT_SIZE) {
-      alert(`Please submit a cropping which is under ${MAX_ATTACHMENT_SIZE_DESCRIPTION}`);
-      return;
-    }
-
-    const croppedFile = new File([ blob ], uncroppedFile.name);
-
-    onSubmit(croppedFile);
-  }, uncroppedFile.type, 1);
 }

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -2,26 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
-"@types/react-image-crop@^8.1.2":
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/@types/react-image-crop/-/react-image-crop-8.1.2.tgz#9c16d6b0b577a63a854a1a895180cc76800e2988"
-  integrity sha512-K6mbw1Bj/CeePnRa78E3v3gIn/EeqlCof5IVU9IPLdzMjOsf+ccn3Qv/vagsH/6eANGgoDz4hG41eJ2kggiuuw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*":
-  version "16.9.41"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.41.tgz#925137ee4d2ff406a0ecf29e8e9237390844002e"
-  integrity sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -144,11 +124,6 @@ charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
 
-clsx@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
-  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -181,11 +156,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-core-js@^3.4.2:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -194,11 +164,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-
-csstype@^2.2.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
-  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
 
 cubic2quad@^1.0.0:
   version "1.1.1"
@@ -435,11 +400,6 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-"js-tokens@^3.0.0 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -474,13 +434,6 @@ lodash@^4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-loose-envify@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
 
 md5@^2.2.1:
   version "2.2.1"
@@ -588,7 +541,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -643,15 +596,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-prop-types@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -671,20 +615,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-react-image-crop@^8.6.4:
-  version "8.6.4"
-  resolved "https://registry.yarnpkg.com/react-image-crop/-/react-image-crop-8.6.4.tgz#51289c22baf7d116575102e885f879af71376388"
-  integrity sha512-5buyhUg9slzW+QGvN2dbpGSI1VqPxxmfEwe19TZXUB7LjW5+ljZOnrTSsteIzeBqmz6ngVucc8l+OrwgcDOSNg==
-  dependencies:
-    clsx "^1.0.4"
-    core-js "^3.4.2"
-    prop-types "^15.7.2"
-
-react-is@^16.8.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 readable-stream@^1.0.33:
   version "1.1.14"


### PR DESCRIPTION
In UX, it was decided that the image upload dialog for the new Contact Us "Screenshots" field didn't need a cropping feature, as most users can pre-crop their screenshot when copying to the clipboard.

(For example, Mac users can press Cmd + Ctrl + Shift + 4.)