### PR TITLE
Custom name fixes

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/QuestionWizard.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/QuestionWizard.jsx
@@ -6,6 +6,7 @@ import {
   IconAlt as Icon,
   Loading,
   Sticky,
+  TextBox,
 } from 'wdk-client/Components';
 import { wrappable } from 'wdk-client/Utils/ComponentUtils';
 import { Seq } from 'wdk-client/Utils/IterableUtils';
@@ -96,6 +97,7 @@ function Navigation(props) {
       onSubmit
     },
     customName,
+    setCustomName,
     showHelpText,
     isAddingStep
   } = props;
@@ -209,7 +211,14 @@ function Navigation(props) {
                 >Analyze results
                 </button>
               )*/}
-              <input className={makeClassName('CustomNameInput')} defaultValue={customName} type="text" name="customName" placeholder="Name this search"/>
+              <TextBox
+                className={makeClassName('CustomNameInput')}
+                value={customName}
+                onChange={setCustomName}
+                type="text"
+                name="customName"
+                placeholder="Name this search"
+              />
             </div>
             {invalid && (
               <div className={makeClassName('InvalidCounts')}>

--- a/Site/webapp/wdkCustomization/js/client/components/QuestionWizard.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/QuestionWizard.jsx
@@ -213,7 +213,7 @@ function Navigation(props) {
               )*/}
               <TextBox
                 className={makeClassName('CustomNameInput')}
-                value={customName}
+                value={customName || ''}
                 onChange={setCustomName}
                 type="text"
                 name="customName"

--- a/Site/webapp/wdkCustomization/js/client/controllers/QuestionWizardController.jsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/QuestionWizardController.jsx
@@ -69,7 +69,7 @@ class QuestionWizardController extends ViewController {
 
   constructor(props) {
     super(props);
-    this.state = { };
+    this.state = { customName: '' };
     this.parameterMap = null;
     this.wizardEventHandlers = mapValues(this.getWizardEventHandlers(), handler => handler.bind(this));
     this.parameterEventHandlers = mapValues(this.getParameterEventHandlers(), handler => handler.bind(this));
@@ -78,6 +78,8 @@ class QuestionWizardController extends ViewController {
     this._getFilterCounts = memoize(this._getFilterCounts, (...args) => JSON.stringify(args));
     this._updateGroupCounts = synchronized(this._updateGroupCounts);
     this._commitParamValueChange = synchronized(debounce(this._commitParamValueChange, 750));
+
+    this.setCustomName = this.setCustomName.bind(this);
   }
 
   getWizardEventHandlers() {
@@ -359,6 +361,10 @@ class QuestionWizardController extends ViewController {
       );
       this.onParamStateChange(param, Object.assign({}, paramState, { fieldStates }));
     }
+  }
+
+  setCustomName(newCustomName) {
+    this.setState({ customName: newCustomName });
   }
 
   onSubmit() {
@@ -843,7 +849,8 @@ class QuestionWizardController extends ViewController {
             wizardState={this.state}
             wizardEventHandlers={this.wizardEventHandlers}
             parameterEventHandlers={this.parameterEventHandlers}
-            customName={this.props.customName}
+            customName={this.state.customName}
+            setCustomName={this.setCustomName}
             isAddingStep={this.props.submissionMetadata.type.startsWith('add-')}
             showHelpText={!this.props.submissionMetadata.type === 'edit-step'}
           />

--- a/Site/webapp/wdkCustomization/js/client/util/QuestionWizardState.js
+++ b/Site/webapp/wdkCustomization/js/client/util/QuestionWizardState.js
@@ -6,7 +6,7 @@ import { getFilterFields } from 'wdk-client/Views/Question/Params/FilterParamNew
 /**
  * Create initial wizard state object
  */
-export function createInitialState(question, recordClass, paramValues, defaultParamValues) {
+export function createInitialState(question, recordClass, paramValues, defaultParamValues, customName) {
 
   const paramUIState = question.parameters.reduce(function(uiState, param) {
     return Object.assign(uiState, { [param.name]: createInitialParamState(param) });
@@ -37,7 +37,8 @@ export function createInitialState(question, recordClass, paramValues, defaultPa
     recordClass,
     activeGroup: undefined,
     updatingParamName: undefined,
-    submitting: undefined
+    submitting: undefined,
+    customName: customName || ''
   };
 }
 


### PR DESCRIPTION
This PR addresses a recently reported bug for the "custom step name" functionality:

When revising a step, submitting a new "custom name" from the search page does not update the step's custom name. (The fix is as in https://github.com/VEuPathDB/WDKClient/pull/53.)

In addition, a related bug is discovered and fixed:

When creating a new strategy/step, submitting a new "custom name" from the wizard does not work. (This is resolved by giving the question wizard controller some missing `customName` state.)