### PR TITLE
Updates to propertly include modern or legacy bundles.

### DIFF
--- a/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
+++ b/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
@@ -8,7 +8,7 @@
     <link href="/{{ webapp_ctx }}/images/{{ displayName }}/favicon.ico" type="image/x-icon" rel="shortcut icon"/>
     <script>
       {# used for webpack. remove this when this can be set at build time. #}
-      window.__asset_path_remove_me_please__ = "/{{ webapp_ctx }}/";
+      window.__asset_path_remove_me_please__ = "/{{ webapp_ctx }}/bundles/";
 
       {# used by EbrcWebsiteCommon to initialize wdk #}
       window.__SITE_CONFIG__ = {
@@ -38,8 +38,8 @@
       {%- endif %}
     </script>
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"/>
-    <link rel="stylesheet" type="text/css" href="/{{ webapp_ctx }}/site-client.bundle.css"/>
-    <script charset="utf8" src="/{{ webapp_ctx }}/site-client.bundle.js" ></script>
+    <link rel="stylesheet" type="text/css" href="/{{ webapp_ctx }}/bundles/site-client.bundle.css"/>
+    <script charset="utf8" src="/{{ webapp_ctx }}/bundles/site-client.bundle.js" ></script>
   </head>
   {% set bodyClassName = 'vpdb-Body' if project != 'ClinEpiDB' and project != 'AllClinEpiDB' and project != 'MicrobiomeDB' else 'wdk-Body' %}
   <body class="{{ bodyClassName }}">

--- a/Model/src/main/java/org/eupathdb/common/controller/AssetBundleFilter.java
+++ b/Model/src/main/java/org/eupathdb/common/controller/AssetBundleFilter.java
@@ -1,0 +1,89 @@
+package org.eupathdb.common.controller;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.gusdb.fgputil.runtime.GusHome;
+
+/**
+ * Servlet filter that returns either modern or legacy assets based on user
+ * agent string
+ */
+public class AssetBundleFilter implements Filter {
+
+  private static final String BASE_PATH = "/bundles/";
+  private static final String virtualBundlePattern = BASE_PATH + "(?!(modern|legacy)/)(.*)";
+
+  @Override
+  public void destroy() {
+    // TODO Auto-generated method stub
+
+  }
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+      throws IOException, ServletException {
+    if (!(servletRequest instanceof HttpServletRequest) || !(servletResponse instanceof HttpServletResponse)) {
+      chain.doFilter(servletRequest, servletResponse);
+      return;
+    }
+    HttpServletRequest req = (HttpServletRequest) servletRequest;
+    HttpServletResponse res = (HttpServletResponse) servletResponse;
+    String path = req.getServletPath();
+    if (path.matches(virtualBundlePattern)) {
+      String userAgentString = req.getHeader("user-agent");
+      String subPath = getSubPath(userAgentString);
+      String resourcePath = path.substring(BASE_PATH.length());
+      String realPath = BASE_PATH + subPath + resourcePath;
+      res.sendRedirect(req.getContextPath() + realPath);
+      return;
+    }
+    chain.doFilter(servletRequest, servletResponse);
+  }
+
+  @Override
+  public void init(FilterConfig config) throws ServletException {
+    // TODO Auto-generated method stub
+
+  }
+
+  private static String getSubPath(String userAgentString) throws IOException {
+    String gusHome = GusHome.getGusHome();
+    System.out.println("gusHome: " + gusHome);
+    String[] command = new String[] {
+      gusHome + "/bin/getBundlesSubPath",
+      userAgentString
+    };
+    ProcessBuilder ps = new ProcessBuilder(command);
+    ps.redirectErrorStream(true);
+    Process pr = ps.start();
+    StringBuilder output = new StringBuilder();
+    try (BufferedReader in = new BufferedReader(new InputStreamReader(pr.getInputStream()))) {
+      String line;
+      while ((line = in.readLine()) != null) {
+        output.append(line);
+      }
+      pr.waitFor();
+    }
+    catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+    if (pr.exitValue() == 0) {
+      return output.toString();
+    }
+    throw new RuntimeException("Error from `bundleSubDirectory`: " + output);
+  }
+  
+}

--- a/Site/site.webpack.config.js
+++ b/Site/site.webpack.config.js
@@ -49,12 +49,6 @@ var scriptLoaders = scripts.map(function(script) {
 module.exports = function configure(additionalConfig) {
   return baseConfig.merge([{
     context: process.cwd(),
-    output: {
-      path: path.join(process.cwd(), 'dist'),
-      filename: '[name].bundle.js',
-      chunkFilename: 'ebrc-chunk-[name].bundle.js',
-      library: 'Ebrc'
-    },
     module: {
       rules: [ ].concat(scriptLoaders),
     },

--- a/Site/webapp/wdkCustomization/js/client/bootstrap.js
+++ b/Site/webapp/wdkCustomization/js/client/bootstrap.js
@@ -5,7 +5,6 @@
 import './publicPath';
 // ###
 
-import '@babel/polyfill';
 import 'custom-event-polyfill';
 import 'whatwg-fetch';
 import 'lib/jquery';

--- a/Site/webapp/wdkCustomization/js/client/publicPath.js
+++ b/Site/webapp/wdkCustomization/js/client/publicPath.js
@@ -1,2 +1,2 @@
 // placeholder used by webpack when making xhr's for code chunks
-__webpack_public_path__ = window.__asset_path_remove_me_please__; // eslint-disable-line
+__webpack_public_path__ = window.__asset_path_remove_me_please__ + __OUTPUT_SUBDIR__; // eslint-disable-line


### PR DESCRIPTION
This PR includes changes that enable the correct bundle (modern or legacy) to be used based on the browser's user agent. If the user agent is detected as "modern", it will be redirected to the modern bundle, otherwise it will be redirected to the legacy bundle.

This PR is co-dependent on https://github.com/VEuPathDB/install/pull/7. `web.xml` will also need to be updated for all cohorts when these are merged.