### PR TITLE
Download Link for Answer tables

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.scss
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.scss
@@ -1,0 +1,5 @@
+.wdk-Answer {
+  .wdk-Icon.fa-download {
+    color: #069;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 
 import { memoize } from 'lodash';
 
+import { AnswerOptions } from 'wdk-client/Actions/AnswerActions';
 import { Props as AnswerControllerProps } from 'wdk-client/Controllers/AnswerController';
+import { WdkService } from 'wdk-client/Core';
 import { AttributeValue, RecordInstance } from 'wdk-client/Utils/WdkModel';
 
 import { MONTHS } from 'ebrc-client/util/formatters';
@@ -47,3 +49,34 @@ const eupathReleaseToSortKey = memoize((eupathRelease: AttributeValue) => {
     Number(versionStr)
   ];
 });
+
+export function downloadAnswer(
+  wdkService: WdkService,
+  searchName: string,
+  {
+    displayInfo: {
+      attributes,
+      pagination,
+      sorting
+    },
+    parameters = {}
+  }: AnswerOptions
+){
+  return wdkService.downloadAnswer({
+    answerSpec: {
+      searchName,
+      searchConfig: {
+        parameters
+      }
+    },
+    formatting: {
+      format: 'attributesTabular',
+      formatConfig: {
+        attachmentType: 'csv',
+        attributes,
+        pagination,
+        sorting
+      }
+    }
+  });
+}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -1,9 +1,10 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { memoize } from 'lodash';
 
 import { AnswerOptions } from 'wdk-client/Actions/AnswerActions';
+import { IconAlt } from 'wdk-client/Components';
 import {
   DEFAULT_PAGINATION,
   DEFAULT_SORTING,
@@ -17,7 +18,17 @@ import { AttributeValue, RecordInstance, ParameterValues } from 'wdk-client/Util
 import { MONTHS } from 'ebrc-client/util/formatters';
 
 export function AnswerController(DefaultComponent: React.ComponentType<AnswerControllerProps>) {
-  return (props: AnswerControllerProps) => <DefaultComponent {...props} customSortBys={ebrcCustomSortBys} />;
+  return (props: AnswerControllerProps) => {
+    const additionalActions = useAdditionalActions(props.ownProps.parameters);
+
+    return (
+      <DefaultComponent
+        {...props}
+        customSortBys={ebrcCustomSortBys}
+        additionalActions={additionalActions}
+      />
+    );
+  };
 }
 
 const ebrcCustomSortBys = {
@@ -56,6 +67,25 @@ const eupathReleaseToSortKey = memoize((eupathRelease: AttributeValue) => {
     Number(versionStr)
   ];
 });
+
+function useAdditionalActions(parameters?: ParameterValues) {
+  const onDownloadButtonClick = useOnDownloadButtonClick(parameters);
+
+  return useMemo(
+    () => [
+      {
+        key: 'download',
+        display: (
+          <button className="btn" onClick={onDownloadButtonClick}>
+            <IconAlt fa="download" />
+            Download
+          </button>
+        )
+      }
+    ],
+    [ onDownloadButtonClick ]
+  )
+}
 
 function useOnDownloadButtonClick(parameters?: ParameterValues) {
   const wdkService = useContext(WdkServiceContext);

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -72,8 +72,9 @@ function useAdditionalActions(props: AnswerControllerProps) {
   const onDownloadButtonClick = useOnDownloadButtonClick(props);
 
   return useMemo(
-    () => onDownloadButtonClick
-      ? [
+    () => onDownloadButtonClick == null
+      ? []
+      : [
           {
             key: 'download',
             display: (
@@ -83,8 +84,7 @@ function useAdditionalActions(props: AnswerControllerProps) {
               </button>
             )
           }
-        ]
-      : [],
+        ],
     [ onDownloadButtonClick ]
   )
 }

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -17,6 +17,8 @@ import { AttributeValue, RecordInstance, ParameterValues } from 'wdk-client/Util
 
 import { MONTHS } from 'ebrc-client/util/formatters';
 
+import './AnswerController.scss';
+
 export function AnswerController(DefaultComponent: React.ComponentType<AnswerControllerProps>) {
   return (props: AnswerControllerProps) => {
     const additionalActions = useAdditionalActions(props.ownProps.parameters);

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
 
 import { memoize } from 'lodash';
 
 import { AnswerOptions } from 'wdk-client/Actions/AnswerActions';
-import { Props as AnswerControllerProps } from 'wdk-client/Controllers/AnswerController';
+import {
+  DEFAULT_PAGINATION,
+  DEFAULT_SORTING,
+  Props as AnswerControllerProps
+} from 'wdk-client/Controllers/AnswerController';
 import { WdkService } from 'wdk-client/Core';
-import { AttributeValue, RecordInstance } from 'wdk-client/Utils/WdkModel';
+import { RootState } from 'wdk-client/Core/State/Types';
+import { WdkServiceContext } from 'wdk-client/Service/WdkService';
+import { AttributeValue, RecordInstance, ParameterValues } from 'wdk-client/Utils/WdkModel';
 
 import { MONTHS } from 'ebrc-client/util/formatters';
 
@@ -49,6 +56,35 @@ const eupathReleaseToSortKey = memoize((eupathRelease: AttributeValue) => {
     Number(versionStr)
   ];
 });
+
+function useOnDownloadButtonClick(parameters?: ParameterValues) {
+  const wdkService = useContext(WdkServiceContext);
+
+  const allAttributes = useSelector((state: RootState) => state.answerView.allAttributes);
+  const question = useSelector((state: RootState) => state.answerView.question);
+
+  if (wdkService == null || allAttributes == null || question == null) {
+    return undefined;
+  }
+
+  return () => {
+    downloadAnswer(
+      wdkService,
+      question.urlSegment,
+      {
+        parameters,
+        displayInfo: {
+          attributes: allAttributes
+            .filter(({ isDisplayable }) => isDisplayable)
+            .map(({ name }) => name),
+          customName: '',
+          pagination: DEFAULT_PAGINATION,
+          sorting: DEFAULT_SORTING
+        }
+      }
+    );
+  };
+}
 
 export function downloadAnswer(
   wdkService: WdkService,

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 
 import { memoize } from 'lodash';
 
@@ -11,9 +10,8 @@ import {
   Props as AnswerControllerProps
 } from 'wdk-client/Controllers/AnswerController';
 import { WdkService } from 'wdk-client/Core';
-import { RootState } from 'wdk-client/Core/State/Types';
 import { WdkServiceContext } from 'wdk-client/Service/WdkService';
-import { AttributeValue, RecordInstance, ParameterValues } from 'wdk-client/Utils/WdkModel';
+import { AttributeValue, RecordInstance } from 'wdk-client/Utils/WdkModel';
 
 import { MONTHS } from 'ebrc-client/util/formatters';
 
@@ -21,7 +19,7 @@ import './AnswerController.scss';
 
 export function AnswerController(DefaultComponent: React.ComponentType<AnswerControllerProps>) {
   return (props: AnswerControllerProps) => {
-    const additionalActions = useAdditionalActions(props.ownProps.parameters);
+    const additionalActions = useAdditionalActions(props);
 
     return (
       <DefaultComponent
@@ -70,32 +68,42 @@ const eupathReleaseToSortKey = memoize((eupathRelease: AttributeValue) => {
   ];
 });
 
-function useAdditionalActions(parameters?: ParameterValues) {
-  const onDownloadButtonClick = useOnDownloadButtonClick(parameters);
+function useAdditionalActions(props: AnswerControllerProps) {
+  const onDownloadButtonClick = useOnDownloadButtonClick(props);
 
   return useMemo(
-    () => [
-      {
-        key: 'download',
-        display: (
-          <button className="btn" onClick={onDownloadButtonClick}>
-            <IconAlt fa="download" />
-            Download
-          </button>
-        )
-      }
-    ],
+    () => onDownloadButtonClick
+      ? [
+          {
+            key: 'download',
+            display: (
+              <button className="btn" onClick={onDownloadButtonClick}>
+                <IconAlt fa="download" />
+                Download
+              </button>
+            )
+          }
+        ]
+      : [],
     [ onDownloadButtonClick ]
   )
 }
 
-function useOnDownloadButtonClick(parameters?: ParameterValues) {
+function useOnDownloadButtonClick(props: AnswerControllerProps) {
   const wdkService = useContext(WdkServiceContext);
 
-  const allAttributes = useSelector((state: RootState) => state.answerView.allAttributes);
-  const question = useSelector((state: RootState) => state.answerView.question);
+  const { parameters } = props.ownProps;
 
-  if (wdkService == null || allAttributes == null || question == null) {
+  const {
+    allAttributes,
+    question
+  } = props.stateProps;
+
+  if (
+    wdkService == null ||
+    allAttributes == null ||
+    question == null
+  ) {
     return undefined;
   }
 

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/AnswerController.tsx
@@ -119,7 +119,9 @@ function useOnDownloadButtonClick(props: AnswerControllerProps) {
 
       // We only offer a download button for answers whose
       // record class offers the nececessary reporter
-      const reporterAvailable = recordClass?.formats.some(
+      // FIXME: Should probably also check whether the reporter
+      // is offered in "download" scope
+      const reporterAvailable = recordClass.formats.some(
         ({ name }) => name === DOWNLOAD_REPORTER_NAME
       );
 
@@ -132,6 +134,8 @@ function useOnDownloadButtonClick(props: AnswerControllerProps) {
           wdkService,
           question.urlSegment,
           parameters ?? {},
+          // FIXME: The downloaded attributes should be
+          // precisely those with "download" scope
           allAttributes
             .filter(({ isDisplayable }) => isDisplayable)
             .map(({ name }) => name),


### PR DESCRIPTION
This PR offers a "Download" button for Ebrc Answer tables. Note that there are some FIXMEs which should be addressed as part of our planned ontology-driven refactor of AnswerController.

Depends on https://github.com/VEuPathDB/WDKClient/pull/71