### PR TITLE
Initial commit of useAttemptActionClickHandler hook

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/hooks/dataRestriction.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/dataRestriction.ts
@@ -1,0 +1,94 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import {
+  Unpack,
+  constant,
+  decode,
+  oneOf,
+  record,
+  string
+} from 'wdk-client/Utils/Json';
+
+import { attemptAction, label } from 'ebrc-client/App/DataRestriction/DataRestrictionActionCreators';
+
+const STUDY_ACTION_CLASS_NAME = 'study-action';
+
+const STUDY_ID_DATA_ATTRIBUTE = 'data-study-id';
+const ARGS_DATA_ATTRIBUTE = 'data-args';
+
+export function useAttemptActionClickHandler() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    function handleActionButtonClick(event: MouseEvent) {
+      if (
+        event.target instanceof HTMLButtonElement &&
+        event.target.classList.contains(STUDY_ACTION_CLASS_NAME)
+      ) {
+        const studyId = event.target.getAttribute(STUDY_ID_DATA_ATTRIBUTE);
+        const actionArgsStr = event.target.getAttribute(ARGS_DATA_ATTRIBUTE);
+
+        if (studyId == null || actionArgsStr == null) {
+          const missingAttributes = [
+            !studyId && STUDY_ID_DATA_ATTRIBUTE,
+            !actionArgsStr && ARGS_DATA_ATTRIBUTE
+          ].filter(x => x);
+
+          const missingAttributesMessage = label(
+            `Clicked on a ${STUDY_ACTION_CLASS_NAME} button with the following missing attribute(s): ` +
+            missingAttributes.join(', ') +
+            '. A Data Restriction action will not be attempted.'
+          );
+
+          console.warn(missingAttributesMessage);
+
+          return;
+        }
+
+        const parsedActionArgs = decode(actionArgs, actionArgsStr);
+
+        dispatch(
+          attemptAction(
+            parsedActionArgs.type,
+            {
+              studyId,
+              ...makeDataRestrictionCallbacks(parsedActionArgs, event)
+            }
+          )
+        );
+      }
+    }
+
+    document.addEventListener('click', handleActionButtonClick);
+
+    return () => {
+      document.removeEventListener('click', handleActionButtonClick);
+    };
+  }, [ dispatch ]);
+}
+
+const actionArgs = oneOf(
+  record({
+    type: constant('download'),
+    downloadUrl: string
+  })
+);
+
+type ActionArgs = Unpack<typeof actionArgs>;
+
+function makeDataRestrictionCallbacks(actionArgs: ActionArgs, event: MouseEvent) {
+  switch (actionArgs.type) {
+    case 'download': {
+      const { ctrlKey } = event;
+      const { downloadUrl } = actionArgs;
+
+      return {
+        onAllow: () => {
+          if (ctrlKey) window.open(downloadUrl, '_blank');
+          else window.location.assign(downloadUrl);
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
Motivation: [this Redmine](https://redmine.apidb.org/issues/43153) calls for allowing model-provided links to be guarded by a `DataRestriction`.

To that end, this PR introduces a `useAttemptActionClickHandler` hook. When invoked, it adds a document-level `click` event listener for `button`s with a class of `study-action` and attributes `data-study-id` and `data-args`. When this listener is invoked with a supported form of `data-args`, an appropriate data restriction action is attempted.

Currently, the only supported form of `data-args` is `{ "type": "download", "downloadUrl": "/href/to/some/download/page" }`, so as to accommodate the motivating Redmine.

To fully resolve the Redmine, Data Dev will also have to update the model for the `DownloadVersion` record table.

**Future work:**

1. Make a React component which can render buttons with a supported form of `ActionArgs`.
2. Use (1) to DRY up the `DownloadLink` component code.
3. Add support for the `record` `DataRestriction` action.
