### PR TITLE
Handle non-ok responses

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/homepage/ContentError.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/ContentError.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Banner } from 'wdk-client/Components';
+
+interface Props {
+  message: string;
+}
+
+export function ContentError(props: Props) {
+  return (
+    <Banner banner={{
+      type: 'error',
+      message: `Content for this section could not be loaded: ${props.message}.`
+    }}/>
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/components/homepage/FeaturedTools.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/FeaturedTools.tsx
@@ -11,6 +11,7 @@ import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import { decode, string } from 'wdk-client/Utils/Json';
 
 import './FeaturedTools.scss';
+import { ContentError } from './ContentError';
 
 const cx = makeClassNameHelper('vpdb-FeaturedTools');
 const bgDarkCx = makeClassNameHelper('vpdb-BgDark');
@@ -32,20 +33,31 @@ type FeaturedToolEntry = {
   output: string
 };
 
-function useFeaturedToolMetadata(): FeaturedToolMetadata | undefined {
+type Result<T> =
+  | { status: 'ok', value: T }
+  | { status: 'error', message: string }
+
+function useFeaturedToolMetadata(): Result<FeaturedToolMetadata> | undefined {
   const communitySiteUrl = useCommunitySiteProjectUrl();
   const [ featuredToolResponseData, setFeaturedToolResponseData ] = useState<FeaturedToolResponseData | undefined>(undefined);
+  const [ featuredToolError, setFeaturedToolError ] = useState<string|undefined>(undefined);
   
   useEffect(() => {
     if (communitySiteUrl != null) {
       (async () => {
-        // FIXME Add basic error-handling 
-        const response = await fetch(`https://${communitySiteUrl}${FEATURED_TOOL_URL_SEGMENT}`, { mode: 'cors' });
-
-        // FIXME Validate this JSON using a Decoder
-        const responseData = await response.json() as FeaturedToolResponseData;
-
-        setFeaturedToolResponseData(responseData);
+        try {
+          const response = await fetch(`https://${communitySiteUrl}${FEATURED_TOOL_URL_SEGMENT}`, { mode: 'cors' });
+          if (response.ok) {
+            const responseData = await response.json() as FeaturedToolResponseData;
+            setFeaturedToolResponseData(responseData);
+          }
+          else {
+            setFeaturedToolError(response.statusText);
+          }
+        }
+        catch(error) {
+          setFeaturedToolError(error.message);
+        }
       })();
     }
   }, [ communitySiteUrl ]);
@@ -60,7 +72,9 @@ function useFeaturedToolMetadata(): FeaturedToolMetadata | undefined {
     [ featuredToolResponseData ]
   );
 
-  return featuredToolMetadata;
+  return featuredToolError != null ? { status: 'error', message: featuredToolError }
+    : featuredToolMetadata != null ? { status: 'ok', value: featuredToolMetadata }
+    : undefined;
 }
 
 const FEATURED_TOOL_KEY = 'homepage-featured-tool';
@@ -74,19 +88,20 @@ export const FeaturedTools = () => {
     JSON.stringify,
     (s: string) => decode(string, s)
   );
-  const selectedToolEntry = !toolMetadata || !selectedTool || !toolMetadata.toolEntries[selectedTool]
+  const selectedToolEntry = !toolMetadata || !selectedTool || !(toolMetadata.status === 'ok' && toolMetadata.value.toolEntries[selectedTool])
     ? undefined
-    : hash.slice(1) ? toolMetadata.toolEntries[hash.slice(1)]
-    : toolMetadata.toolEntries[selectedTool];
+    : hash.slice(1) ? toolMetadata.value.toolEntries[hash.slice(1)]
+    : toolMetadata.value.toolEntries[selectedTool];
 
   useEffect(() => {
     if (
       toolMetadata && 
-      toolMetadata.toolListOrder.length > 0 && 
-      toolMetadata.toolEntries[toolMetadata.toolListOrder[1]] &&
+      toolMetadata.status === 'ok' &&
+      toolMetadata.value.toolListOrder.length > 0 && 
+      toolMetadata.value.toolEntries[toolMetadata.value.toolListOrder[1]] &&
       (!selectedToolEntry)
     ) {
-      setSelectedTool(toolMetadata.toolListOrder[1]);
+      setSelectedTool(toolMetadata.value.toolListOrder[1]);
     }
   }, [ toolMetadata ]);
 
@@ -98,9 +113,11 @@ export const FeaturedTools = () => {
       {
         !toolMetadata 
           ? <Loading />
+          : toolMetadata.status === 'error'
+            ? <ContentError message={toolMetadata.message}/>
           : <div className={cx('List')}>          
               <FeaturedToolList
-                toolMetadata={toolMetadata}
+                toolMetadata={toolMetadata.value}
                 setSelectedTool={setSelectedTool}
                 selectedTool={selectedToolEntry?.identifier}
               />

--- a/Site/webapp/wdkCustomization/js/client/components/homepage/FeaturedTools.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/FeaturedTools.tsx
@@ -48,6 +48,7 @@ function useFeaturedToolMetadata(): Result<FeaturedToolMetadata> | undefined {
         try {
           const response = await fetch(`https://${communitySiteUrl}${FEATURED_TOOL_URL_SEGMENT}`, { mode: 'cors' });
           if (response.ok) {
+            // FIXME Validate this JSON using a Decoder
             const responseData = await response.json() as FeaturedToolResponseData;
             setFeaturedToolResponseData(responseData);
           }

--- a/Site/webapp/wdkCustomization/js/client/components/homepage/WorkshopExercises.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/WorkshopExercises.tsx
@@ -5,6 +5,7 @@ import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 
 import { combineClassNames } from 'ebrc-client/components/homepage/Utils';
 import { useCommunitySiteRootUrl, useCommunitySiteContentProjectUrl } from 'ebrc-client/hooks/staticData';
+import { ContentError } from './ContentError';
 
 import './WorkshopExercises.scss';
 
@@ -51,20 +52,32 @@ type ExerciseEntry = {
   description: string
 };
 
-function useCardMetadata(): CardMetadata | undefined {
+type Result<T> =
+  | { status: 'ok', value: T }
+  | { status: 'error', message: string }
+
+function useCardMetadata(): Result<CardMetadata> | undefined {
   const communitySiteUrl = useCommunitySiteContentProjectUrl();
   const [ workshopExercisesResponseData, setWorkshopExercisesResponseData ] = useState<WorkshopExercisesResponseData | undefined>(undefined);
+  const [ workshopExercisesResponseError, setWorkshopExercisesResponseError ] = useState<string | undefined>();
 
   useEffect(() => {
     if (communitySiteUrl != null) {
       (async () => {
-        // FIXME Add basic error-handling
-        const response = await fetch(`https://${communitySiteUrl}/${WORKSHOP_EXERCISES_URL_SEGMENT}`, { mode: 'cors' });
-
-        // FIXME Validate this JSON using a Decoder
-        const responseData = await response.json() as WorkshopExercisesResponseData;
-
-        setWorkshopExercisesResponseData(responseData);
+        try {
+          const response = await fetch(`https://${communitySiteUrl}/${WORKSHOP_EXERCISES_URL_SEGMENT}`, { mode: 'cors' });
+          if (response.ok) {
+            // FIXME Validate this JSON using a Decoder
+            const responseData = await response.json() as WorkshopExercisesResponseData;
+            setWorkshopExercisesResponseData(responseData);
+          }
+          else {
+            setWorkshopExercisesResponseError(response.statusText);
+          }
+        }
+        catch (error) {
+          setWorkshopExercisesResponseError(error.message);
+        }
       })();
     }
   }, [ communitySiteUrl ]);
@@ -92,8 +105,9 @@ function useCardMetadata(): CardMetadata | undefined {
       },
     [ workshopExercisesResponseData ]
   );
-
-  return cardMetadata;
+  return workshopExercisesResponseError != null ? { status: 'error', message: workshopExercisesResponseError }
+    : cardMetadata != null ? { status: 'ok', value: cardMetadata }
+    : undefined;
 }
 
 export const WorkshopExercises = () => {
@@ -126,8 +140,9 @@ export const WorkshopExercises = () => {
       {
         !cardMetadata
           ? <Loading />
+          : cardMetadata.status === 'error' ? <ContentError message={cardMetadata.message}/>
           : <CardList
-              cardMetadata={cardMetadata}
+              cardMetadata={cardMetadata.value}
               isExpanded={isExpanded}
             />
       }


### PR DESCRIPTION
If a request for static content results in a response that is not `ok`, show an error message where the content would be displayed.