### PR TITLE
Site Search: use pruned organism tree

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/hooks/organisms.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/organisms.ts
@@ -1,5 +1,5 @@
 import { useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
-import { pruneNodesWithOneExtendingChild } from 'ebrc-client/util/organisms';
+import { pruneNodesWithSingleExtendingChild } from 'ebrc-client/util/organisms';
 
 // TODO Make these configurable via model.prop, and when not defined, always return an empty tree.
 // This way non-genomic sites can call this without effect, while keeping the thrown error if
@@ -18,7 +18,7 @@ export function useOrganismTree(offerOrganismFilter: boolean) {
     const orgParam  = taxonQuestion.parameters.find(p => p.name == ORGANISM_PARAM_NAME);
 
     if (orgParam?.type == 'multi-pick-vocabulary' && orgParam?.displayType == 'treeBox') {
-      return pruneNodesWithOneExtendingChild(orgParam.vocabulary);
+      return pruneNodesWithSingleExtendingChild(orgParam.vocabulary);
     }
 
     throw new Error(TAXON_QUESTION_NAME + " does not contain treebox enum param " + ORGANISM_PARAM_NAME);

--- a/Site/webapp/wdkCustomization/js/client/hooks/organisms.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/organisms.ts
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import { useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
-import { TreeBoxVocabNode } from 'wdk-client/Utils/WdkModel';
+import { pruneNodesWithOneExtendingChild } from 'ebrc-client/util/organisms';
 
 // TODO Make these configurable via model.prop, and when not defined, always return an empty tree.
 // This way non-genomic sites can call this without effect, while keeping the thrown error if
@@ -18,8 +17,8 @@ export function useOrganismTree(offerOrganismFilter: boolean) {
     const taxonQuestion = await wdkService.getQuestionAndParameters(TAXON_QUESTION_NAME);
     const orgParam  = taxonQuestion.parameters.find(p => p.name == ORGANISM_PARAM_NAME);
 
-    if (orgParam?.type == 'multi-pick-vocabulary' && orgParam?.displayType == "treeBox") {
-      return orgParam.vocabulary;
+    if (orgParam?.type == 'multi-pick-vocabulary' && orgParam?.displayType == 'treeBox') {
+      return pruneNodesWithOneExtendingChild(orgParam.vocabulary);
     }
 
     throw new Error(TAXON_QUESTION_NAME + " does not contain treebox enum param " + ORGANISM_PARAM_NAME);

--- a/Site/webapp/wdkCustomization/js/client/util/organism.ts
+++ b/Site/webapp/wdkCustomization/js/client/util/organism.ts
@@ -1,0 +1,10 @@
+import { stripHTML } from 'wdk-client/Utils/DomUtils';
+import { Node } from 'wdk-client/Utils/TreeUtils'
+import { TreeBoxVocabNode } from 'wdk-client/Utils/WdkModel';
+
+export function isNodeWithOneExtendingChild(node: Node<TreeBoxVocabNode>) {
+  return (
+    node.children.length === 1 &&
+    stripHTML(node.children[0].data.display).startsWith(stripHTML(node.data.display))
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/util/organisms.ts
+++ b/Site/webapp/wdkCustomization/js/client/util/organisms.ts
@@ -4,14 +4,14 @@ import { stripHTML } from 'wdk-client/Utils/DomUtils';
 import { Node, pruneDescendantNodes } from 'wdk-client/Utils/TreeUtils'
 import { TreeBoxVocabNode } from 'wdk-client/Utils/WdkModel';
 
-export function pruneNodesWithOneExtendingChild(organismTree: Node<TreeBoxVocabNode>) {
+export function pruneNodesWithSingleExtendingChild(organismTree: Node<TreeBoxVocabNode>) {
   return pruneDescendantNodes(
-    negate(isNodeWithOneExtendingChild),
+    negate(isNodeWithSingleExtendingChild),
     organismTree
   );
 }
 
-export function isNodeWithOneExtendingChild(node: Node<TreeBoxVocabNode>) {
+export function isNodeWithSingleExtendingChild(node: Node<TreeBoxVocabNode>) {
   return (
     node.children.length === 1 &&
     stripHTML(node.children[0].data.display).startsWith(stripHTML(node.data.display))

--- a/Site/webapp/wdkCustomization/js/client/util/organisms.ts
+++ b/Site/webapp/wdkCustomization/js/client/util/organisms.ts
@@ -1,6 +1,15 @@
+import { negate } from 'lodash'
+
 import { stripHTML } from 'wdk-client/Utils/DomUtils';
-import { Node } from 'wdk-client/Utils/TreeUtils'
+import { Node, pruneDescendantNodes } from 'wdk-client/Utils/TreeUtils'
 import { TreeBoxVocabNode } from 'wdk-client/Utils/WdkModel';
+
+export function pruneNodesWithOneExtendingChild(organismTree: Node<TreeBoxVocabNode>) {
+  return pruneDescendantNodes(
+    negate(isNodeWithOneExtendingChild),
+    organismTree
+  );
+}
 
 export function isNodeWithOneExtendingChild(node: Node<TreeBoxVocabNode>) {
   return (


### PR DESCRIPTION
This PR updates the site search organism tree so that nodes with a single extending child are pruned. (By an "extending child," we mean a child whose display text starts with the display text of its parent.)

Depends on https://github.com/VEuPathDB/WDKClient/pull/114