### PR TITLE
Use the __total__ group state for initial count

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/controllers/QuestionWizardController.jsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/QuestionWizardController.jsx
@@ -387,7 +387,7 @@ class QuestionWizardController extends ViewController {
                 this.props.question, this.props.paramValues, this.props.defaultParamValues,
                 this.props.groupUIState, activeGroupIx
               ),
-              initialCount: constructInitialCount(this.props.question, this.props.paramUIState, activeGroupIx),
+              initialCount: this.props.groupUIState.__total__.filteredCountState,
               paramUIState: this.props.paramUIState,
               paramValues: this.props.paramValues,
               question: this.props.question,


### PR DESCRIPTION
This PR finalizes a change to how the initial group count for the wizard is loaded. It depends on https://github.com/VEuPathDB/WDKClient/pull/116.