### PR TITLE
Make SearchCheckboxTree wrappable

### DIFF
--- a/Client/src/components/homepage/SearchPane.tsx
+++ b/Client/src/components/homepage/SearchPane.tsx
@@ -8,7 +8,7 @@ import { LinksPosition } from '@veupathdb/wdk-client/lib/Components/CheckboxTree
 import { RootState } from '@veupathdb/wdk-client/lib/Core/State/Types';
 import { useSessionBackedState } from '@veupathdb/wdk-client/lib/Hooks/SessionBackedState';
 import { CategoryTreeNode, getDisplayName, getTargetType, getRecordClassUrlSegment, getTooltipContent } from '@veupathdb/wdk-client/lib/Utils/CategoryUtils';
-import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { makeClassNameHelper, wrappable } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { decode, arrayOf, string } from '@veupathdb/wdk-client/lib/Utils/Json';
 import { Question } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
@@ -19,7 +19,7 @@ import './SearchPane.scss';
 const cx = makeClassNameHelper('ebrc-SearchPane');
 const EXPANDED_BRANCHES_SESSION_KEY = 'homepage-left-panel-expanded-branch-ids';
 
-type Props = {
+export type Props = {
   containerClassName?: string,
   searchTree: CategoryTreeNode | undefined
 };
@@ -53,7 +53,7 @@ export const SearchPane = (props: Props) => {
   );
 }
 
-type SearchCheckboxTreeProps = {
+export type SearchCheckboxTreeProps = {
   searchTree?: CategoryTreeNode,
   searchTerm: string,
   expandedBranches: string[],
@@ -63,7 +63,7 @@ type SearchCheckboxTreeProps = {
   showSearchBox?: boolean
 };
 
-export const SearchCheckboxTree = (props: SearchCheckboxTreeProps) => {
+export const SearchCheckboxTree = wrappable((props: SearchCheckboxTreeProps) => {
   const noSelectedLeaves = useMemo(
     () => [] as string[],
     []
@@ -92,7 +92,7 @@ export const SearchCheckboxTree = (props: SearchCheckboxTreeProps) => {
         showSearchBox={props.showSearchBox != null ? props.showSearchBox : true}
         linksPosition={props.linksPosition != null ? props.linksPosition : LinksPosition.Top}
       />;
-}
+});
 
 const renderNodeFactory = (questionsByUrlSegment: Record<string, Question> | undefined = {}) => (node: any, path: number[] | undefined) => {
   const isSearch = getTargetType(node) === 'search';

--- a/Client/src/components/index.js
+++ b/Client/src/components/index.js
@@ -11,3 +11,4 @@ export { default as TabularReporterFormSubmitButtons } from './reporters/Tabular
 export { SiteSearchInput } from 'ebrc-client/components/SiteSearch/SiteSearchInput';
 export { default as DownloadLink } from 'ebrc-client/App/Studies/DownloadLink';
 export { default as DataRestrictionDaemon } from 'ebrc-client/App/DataRestriction/DataRestrictionDaemon';
+export { SearchCheckboxTree } from 'ebrc-client/components/homepage/SearchPane';


### PR DESCRIPTION
Use case: for the search trees which appear on the genomics site home page and header, we want to restrict tree of available searches based on the user's preferred organisms.