### PR TITLE
References include genomics internal hyperlink

### DIFF
--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -124,24 +124,38 @@ function References(props) {
   if (questions == null || recordClasses == null) {
     return null;
   }
+  console.log(props)
+  console.log(questions)
+  console.log(recordClasses)
+  console.log(props.value)
   let value = props.value
-  .filter(row => row.target_type === 'question')
   .map(row => {
-    let name = row.target_name;
-    let question = questions.find(q => q.fullName === name);
+    if (row.target_type === 'question'){
+      let name = row.target_name;
+      let question = questions.find(q => q.fullName === name);
 
-    if (question == null) throw new Error("cannot find question with name:" + name) ;
+      if (question == null) throw new Error("cannot find question with name:" + name) ;
 
-    let recordClass = recordClasses.find(r => r.urlSegment === question.outputRecordClassName);
-    let searchName = `Identify ${recordClass.displayNamePlural} based on ${question.displayName}`;
-    return (
-      <li key={name}>
-        <Link to={`/search/${recordClass.urlSegment}/${question.urlSegment}`}>
-          {searchName}
-        </Link>
-      </li>
-    );
-  });
+      let recordClass = recordClasses.find(r => r.urlSegment === question.outputRecordClassName);
+      let searchName = `Identify ${recordClass.displayNamePlural} based on ${question.displayName}`;
+      return (
+        <li key={name}>
+          <Link to={`/search/${recordClass.urlSegment}/${question.urlSegment}`}>
+            {searchName}
+          </Link>
+        </li>
+      );
+    } else {
+      // Then return the text and url
+      return (
+        <li>
+          <Link to={`${row.url}`}>
+            {row.text}
+          </Link>
+        </li>
+      );
+    }
+   });
   return value.length === 0 ? <em>No data available</em> : <ul>{value}</ul>;
 }
 

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -124,13 +124,9 @@ function References(props) {
   if (questions == null || recordClasses == null) {
     return null;
   }
-  console.log(props)
-  console.log(questions)
-  console.log(recordClasses)
-  console.log(props.value)
   let value = props.value
   .map(row => {
-    if (row.target_type === 'question'){
+    if (row.link_type === 'question'){
       let name = row.target_name;
       let question = questions.find(q => q.fullName === name);
 
@@ -146,10 +142,11 @@ function References(props) {
         </li>
       );
     } else {
-      // Then return the text and url
+      // Then return the text and url. Note we still need to add keys for each li.
+      let cleanUrl = row.url.replace('/a/app','');
       return (
         <li>
-          <Link to={`${row.url}`}>
+          <Link to={`${cleanUrl}`}>
             {row.text}
           </Link>
         </li>

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -125,7 +125,7 @@ function References(props) {
     return null;
   }
   let value = props.value
-  .map(row => {
+  .map((row, index) => {
     if (row.link_type === 'question'){
       let name = row.target_name;
       let question = questions.find(q => q.fullName === name);
@@ -142,10 +142,10 @@ function References(props) {
         </li>
       );
     } else {
-      // Then return the text and url. Note we still need to add keys for each li.
+      // Then return the text and url.
       let cleanUrl = row.url.replace('/a/app','');
       return (
-        <li>
+        <li key={index}>
           <Link to={`${cleanUrl}`}>
             {row.text}
           </Link>


### PR DESCRIPTION
Handles new References table format implemented by PR [#5](https://github.com/VEuPathDB/EbrcModelCommon/pull/5) in EbrcModelCommon. 

Notes: Uses `link_type` instead of `target_type` to distinguish between cases. We now filter by `target_type='question'` in the References table sql instead.
Additionally, use of `key={index}` is less than [ideal](https://reactjs.org/docs/lists-and-keys.html). Any other suggestions for a key value would be appreciated!