### PR TITLE
Organism genome record cleanup

### DIFF
--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -52,7 +52,8 @@ export function RecordHeading(props) {
     contact,
     email,
     institution,
-    organism_prefix
+    organism_prefix,
+    newcategory,
   } = attributes;
 
   let version = tables.Version && tables.Version[0];
@@ -95,6 +96,13 @@ export function RecordHeading(props) {
           <div className="eupathdb-RecordOverviewItem">
             <strong>Source version: </strong>
             <span>{renderSourceVersion(version)}</span>
+          </div>
+        ) : null}
+
+        {newcategory ? (
+          <div className="eupathdb-RecordOverviewItem">
+            <strong>Category: </strong>
+            <span>{newcategory}</span>
           </div>
         ) : null}
 

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -31,16 +31,39 @@ function renderPrimaryContact(contact, institution, email, record) {
         );
 }
 
-function renderSourceVersion(version) {
-  return (
-    <span>
-      {version.version}&nbsp;
-      <i className="fa fa-question-circle" style={{ color: 'blue' }}
-        title={'The data provider\'s version number or publication date, from' +
-        ' the site the data was acquired. In the rare case neither is available,' +
-        ' the download date.'}/>
-    </span>
-  );
+function renderSourceVersion(version, newcategory) {
+  if (newcategory === 'Genomics') {
+    return (
+      <span>
+        {version}&nbsp;
+        <i className="fa fa-question-circle" style={{ color: 'blue' }}
+        title={'The source versions from' +
+        ' the site the data was acquired.'}/>
+      </span>
+    );
+  } else {
+    return (
+      <span>
+        {version.version}&nbsp;
+        <i className="fa fa-question-circle" style={{ color: 'blue' }}
+          title={'The data provider\'s version number or publication date, from' +
+          ' the site the data was acquired. In the rare case neither is available,' +
+          ' the download date.'}/>
+      </span>
+    );
+  }
+}
+
+
+function getSourceVersion(attributes, tables) {
+  let version;
+  if (attributes.newcategory === 'Genomics') {
+    version = attributes.functional_annotation_version ? attributes.genome_version + ", " + attributes.annotation_version + ", " + attributes.functional_annotation_version : attributes.genome_version + ", " + attributes.annotation_version;
+  } else {
+    version = tables.Version && tables.Version[0];
+  }
+
+  return (version);
 }
 
 export function RecordHeading(props) {
@@ -57,8 +80,7 @@ export function RecordHeading(props) {
     megabase_pairs
   } = attributes;
 
-
-  let version = tables.Version && tables.Version[0];
+  let version = getSourceVersion(attributes, tables);
   let primaryPublication = getPrimaryPublication(record);
 
   return (
@@ -96,8 +118,8 @@ export function RecordHeading(props) {
 
         {version ? (
           <div className="eupathdb-RecordOverviewItem">
-            <strong>Source version: </strong>
-            <span>{renderSourceVersion(version)}</span>
+            <strong>Source version(s): </strong>
+            <span>{renderSourceVersion(version, newcategory)}</span>
           </div>
         ) : null}
 

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -54,7 +54,9 @@ export function RecordHeading(props) {
     institution,
     organism_prefix,
     newcategory,
+    megabase_pairs
   } = attributes;
+
 
   let version = tables.Version && tables.Version[0];
   let primaryPublication = getPrimaryPublication(record);
@@ -112,7 +114,15 @@ export function RecordHeading(props) {
             <span>{eupath_release}</span>
           </div>
         ) : null}
-      </div>
+     
+        {megabase_pairs ? (
+          <div className="eupathdb-RecordOverviewItem">
+            <strong>Megabase Pairs: </strong>
+            <span>{megabase_pairs}</span>
+          </div>
+        ) : null} 
+
+     </div>
     </div>
   );
 }

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -87,15 +87,18 @@ export function RecordHeading(props) {
     <div>
       <props.DefaultComponent {...props}/>
       <div className="wdk-RecordOverview eupathdb-RecordOverview">
-        <div className="eupathdb-RecordOverviewItem">
-          <strong>Summary: </strong>
-          <span style={{ whiteSpace: 'normal' }} dangerouslySetInnerHTML={{__html: summary}}/>
-        </div>
-
+        
         {organism_prefix ? (
           <div className="eupathdb-RecordOverviewItem">
             <strong>Organism (source or reference): </strong>
             <span dangerouslySetInnerHTML={{__html: organism_prefix}}/>
+          </div>
+        ) : null}
+
+        {newcategory ? (
+          <div className="eupathdb-RecordOverviewItem">
+            <strong>Category: </strong>
+            <span>{newcategory}</span>
           </div>
         ) : null}
 
@@ -115,18 +118,10 @@ export function RecordHeading(props) {
           </div>
         ) : null}
 
-
         {version ? (
           <div className="eupathdb-RecordOverviewItem">
             <strong>Source version(s): </strong>
             <span>{renderSourceVersion(version, newcategory)}</span>
-          </div>
-        ) : null}
-
-        {newcategory ? (
-          <div className="eupathdb-RecordOverviewItem">
-            <strong>Category: </strong>
-            <span>{newcategory}</span>
           </div>
         ) : null}
 
@@ -136,6 +131,11 @@ export function RecordHeading(props) {
             <span>{eupath_release}</span>
           </div>
         ) : null}
+        
+        <div className="eupathdb-RecordOverviewItem">
+          <strong>Summary: </strong>
+          <span style={{ whiteSpace: 'normal' }} dangerouslySetInnerHTML={{__html: summary}}/>
+        </div>
      
         {megabase_pairs ? (
           <div className="eupathdb-RecordOverviewItem">


### PR DESCRIPTION
The goal of this PR is to collect and simplify data shown on the dataset record pages.

Relies on associated PRs [7](https://github.com/VEuPathDB/EbrcModelCommon/pull/7) in EbrcModelCommon and [29](https://github.com/VEuPathDB/ApiCommonWebsite/pull/29) in ApiCommonWebsite.

## Updates
- Can use `newcategory` to make decisions about what to show and how. Specifically for `version`.
- Moved `category` to the `RecordHeading`.
- Added Megabase Pairs for Genomics datasets.
- Reorganized the `RecordHeading`. Summary is often very long and should probably be last or close to it.

## Notes
- Currently we have left the ordering of the attributes in the `RecordHeading` alone, but we may consider reordering them so that the dataset summary is last.
- The help text for Genomics page Source Version(s) could be improved.
- When rendering the source version for Genomics pages, we assume at least the `genome_annotation` and `annotation_version' are defined. We should rewrite the logic if this is not true.