### PR TITLE
Introduce useAttemptActionCallback hook

### DIFF
--- a/Client/src/App/DataRestriction/DataRestrictionActionCreators.js
+++ b/Client/src/App/DataRestriction/DataRestrictionActionCreators.js
@@ -16,7 +16,7 @@ export function attemptAction(action, details = {}) {
       return checkPermissions(user).then(permissions => {
         return handleAction(
           permissions,
-          user,
+          user.properties.approvedStudies,
           studies[0],
           action,
           details
@@ -45,7 +45,7 @@ export function clearRestrictions() {
 }
 
 // Create restriction action
-function handleAction(permissions, user, studies, action, { studyId, onAllow, onDeny }) {
+function handleAction(permissions, approvedStudies, studies, action, { studyId, onAllow, onDeny }) {
   console.info(label('Restriction Encountered:'), { action, studyId });
   const study = studies.find(study => studyId === study.id);
 
@@ -57,7 +57,7 @@ function handleAction(permissions, user, studies, action, { studyId, onAllow, on
     return clearRestrictions();
   }
 
-  if (isAllowedAccess({ permissions, user, action, study })) {
+  if (isAllowedAccess({ permissions, approvedStudies, action, study })) {
     if (typeof onAllow === 'function') onAllow();
     return unrestricted(study, action);
   }

--- a/Client/src/App/DataRestriction/DataRestrictionUtils.js
+++ b/Client/src/App/DataRestriction/DataRestrictionUtils.js
@@ -178,10 +178,10 @@ export function getRestrictionMessage ({ action, study }) {
 
 // CHECKERS! =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-export function isAllowedAccess ({ permissions, user, action, study }) {
+export function isAllowedAccess ({ permissions, approvedStudies, action, study }) {
   if (sessionStorage.getItem('restriction_override') === 'true') return true;
   if (!(study.access in accessLevels)) throw new Error(`Unknown access level "${study.access}".`);
-  if (isUserApprovedForStudy(permissions, user.properties.approvedStudies, study.id)) return true;
+  if (isUserApprovedForStudy(permissions, approvedStudies, study.id)) return true;
   if (accessLevels[study.access][action] === Require.allow) return true;
   //if (accessLevels[study.access][action] === Require.login) if (!user.isGuest) return true;
   // access not allowed, we need to build the modal popup


### PR DESCRIPTION
This PR introduces a `useAttemptActionCallback`, and illustrates its use by refactoring the existing `useAttemptActionClickHandler`.

**Followup work:**

1. Fix the `WdkDepdendenciesContext` typo.
2. Retire the `approvedStudies` user property. (It has been superseded by the dataset access service's `/permissions` endpoint.)
3. Whenever `DataRestrictionUtils` is converted to TypeScript, restrict type of the `action: string` argument accordingly.