### PR TITLE
Fix race condition DataRestrictionDaemon

### DIFF
--- a/Client/src/App/DataRestriction/DataRestrictionDaemon.jsx
+++ b/Client/src/App/DataRestriction/DataRestrictionDaemon.jsx
@@ -7,6 +7,8 @@ import { useLocation } from 'react-router';
 import { UserSessionActions } from '@veupathdb/wdk-client/lib/Actions';
 import { wrappable } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
+import { usePermissions } from '../../hooks/permissions';
+
 import { clearRestrictions } from './DataRestrictionActionCreators';
 import DataRestrictionModal from './DataRestrictionModal';
 
@@ -16,7 +18,6 @@ function DataRestrictionDaemon(props) {
   const {
     dataRestriction,
     user,
-    permissions,
     webAppUrl,
     clearRestrictions,
     showLoginForm,
@@ -28,12 +29,18 @@ function DataRestrictionDaemon(props) {
     clearRestrictions();
   }, [location.pathname]);
 
-  if (dataRestriction == null || user == null) return null;
+  const permissionsValue = usePermissions();
+
+  if (
+    dataRestriction == null ||
+    user == null ||
+    permissionsValue.loading
+  ) return null;
 
   return !dataRestriction ? null : (
     <DataRestrictionModal
       user={user}
-      permissions={permissions}
+      permissions={permissionsValue.permissions}
       study={dataRestriction.study}
       action={dataRestriction.action}
       webAppUrl={webAppUrl}
@@ -46,7 +53,6 @@ function DataRestrictionDaemon(props) {
 DataRestrictionDaemon.propTypes = {
   dataRestriction: PropTypes.object,
   user: PropTypes.object,
-  permissions: PropTypes.object.isRequired,
   webAppUrl: PropTypes.string.isRequired,
   clearRestrictions: PropTypes.func.isRequired,
   showLoginForm: PropTypes.func.isRequired,

--- a/Client/src/App/DataRestriction/DataRestrictionModal.jsx
+++ b/Client/src/App/DataRestriction/DataRestrictionModal.jsx
@@ -164,7 +164,7 @@ DataRestrictionModal.propTypes = {
   permissions: PropTypes.object.isRequired,
   study: PropTypes.object.isRequired,
   action: PropTypes.string.isRequired,
-  when: PropTypes.bool.isRequired,
+  when: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   showLoginForm: PropTypes.func.isRequired,
   webAppUrl: PropTypes.string.isRequired

--- a/Client/src/App/Showcase/Showcase.jsx
+++ b/Client/src/App/Showcase/Showcase.jsx
@@ -6,7 +6,6 @@ import { IconAlt as Icon } from '@veupathdb/wdk-client/lib/Components';
 import CardList from './CardList';
 
 import './Showcase.scss';
-import ShowcaseFilter from './ShowcaseFilter';
 
 class Showcase extends React.Component {
   constructor (props) {

--- a/Client/src/App/Showcase/Showcase.jsx
+++ b/Client/src/App/Showcase/Showcase.jsx
@@ -45,7 +45,7 @@ class Showcase extends React.Component {
     const { handleFilter } = this;
     const { filteredItems: list } = this.state;
     const { content, prefix, attemptAction } = this.props;
-    const { title, viewAllUrl, viewAllAppUrl, filters, filtersLabel, contentType, contentNamePlural, items, description, isLoading, isExpandable, tableViewLink, cardComponent, getSearchStringForItem, matchPredicate } = content;
+    const { title, viewAllUrl, viewAllAppUrl, filters, filtersLabel, contentType, contentNamePlural, items, description, isLoading, isExpandable, tableViewLink, cardComponent, getSearchStringForItem, matchPredicate, permissions } = content;
     const cards = this.renderCardList(contentType, cardComponent, {
       attemptAction,
       contentNamePlural,
@@ -57,7 +57,8 @@ class Showcase extends React.Component {
       isExpandable,
       tableViewLink,
       getSearchStringForItem,
-      matchPredicate
+      matchPredicate,
+      permissions
     });
 
 

--- a/Client/src/App/Studies/StudyActionCreators.js
+++ b/Client/src/App/Studies/StudyActionCreators.js
@@ -68,15 +68,11 @@ function loadStudies() {
 
 
 export function fetchStudies(wdkService) {
-  const user$ = wdkService.getCurrentUser();
-
   return Promise.all([
     wdkService.getConfig().then(config => config.projectId),
     wdkService.getQuestions(),
     wdkService.getRecordClasses(),
-    wdkService.getStudies('__ALL_ATTRIBUTES__', '__ALL_TABLES__'),
-    user$,
-    user$.then(checkPermissions)
+    wdkService.getStudies('__ALL_ATTRIBUTES__', '__ALL_TABLES__')
   ]).then(spread(formatStudies))
 }
 
@@ -104,7 +100,7 @@ const parseStudy = mapProps({
 });
   
 
-function formatStudies(projectId, questions, recordClasses, answer, user, permissions) {
+function formatStudies(projectId, questions, recordClasses, answer) {
   const questionsByName = keyBy(questions, 'fullName');
   const recordClassesByName = keyBy(recordClasses, 'urlSegment');
 

--- a/Client/src/components/Permissions.tsx
+++ b/Client/src/components/Permissions.tsx
@@ -1,31 +1,23 @@
 import React from 'react';
 
-import { defaultMemoize } from 'reselect';
+import { UserPermissions } from 'ebrc-client/StudyAccess/permission';
+import { usePermissions } from 'ebrc-client/hooks/permissions';
 
-import { usePromise } from '@veupathdb/wdk-client/lib/Hooks/PromiseHook';
-import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
-import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
-
-import { UserPermissions, checkPermissions } from 'ebrc-client/StudyAccess/permission';
-
-const memoizedPermissionsCheck = defaultMemoize(function (user: User | undefined) {
-  return user && checkPermissions(user);
-});
-
-export function withPermissions<P>(Component: React.ComponentType<P & { permissions: UserPermissions }>): React.ComponentType<P> {
+/**
+ * This higher-order component fetches the user's UserPermissions and
+ * passes them to the "Component".
+ *
+ * Note: rendering of the "Component" is deferred until the fetch is
+ * complete. Prefer to invoke "usePermissions" within the
+ * "Component" whenever the "Component" should be rendered concurrently
+ * with the fetching of the UserPermissions.
+ */
+ export function withPermissions<P>(Component: React.ComponentType<P & { permissions: UserPermissions }>): React.ComponentType<P> {
   return function(props) {
-    const user = useWdkService(
-      wdkService => wdkService.getCurrentUser(),
-      []
-    );
+    const permissionsValue = usePermissions();
 
-    const { value: permissions } = usePromise(
-      async () => memoizedPermissionsCheck(user),
-      [ user ]
-    );
-
-    return permissions == null
+    return permissionsValue.loading
       ? null
-      : <Component {...props} permissions={permissions} />;
+      : <Component {...props} permissions={permissionsValue.permissions} />;
   }
 }

--- a/Client/src/hooks/permissions.ts
+++ b/Client/src/hooks/permissions.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+import { defaultMemoize } from 'reselect';
+
+import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
+
+import { UserPermissions, checkPermissions } from 'ebrc-client/StudyAccess/permission';
+
+export type AsyncUserPermissions =
+  | { loading: true }
+  | { loading: false, permissions: UserPermissions };
+
+const memoizedPermissionsCheck = defaultMemoize(function (user: User) {
+  return checkPermissions(user);
+});
+
+export function usePermissions(): AsyncUserPermissions {
+  const permissions = useWdkService(
+    async wdkService => memoizedPermissionsCheck(await wdkService.getCurrentUser()),
+    []
+  );
+
+  return useMemo(
+    () => permissions == null
+      ? { loading: true }
+      : { loading: false, permissions },
+    [ permissions ]
+  );
+}


### PR DESCRIPTION
This PR:

1. Fixes a race condition which was causing the `DataRestrictionModal` to be wrongly cleared. (Also requires the companion PR for ClinEpiWebsite to be merged.)
2. Updates `Showcase` so that the `StudyCard`'s `permissions` can be passed through the containing `Showcase`, as opposed to wrapping `StudyCard` via `withPermissions`. (Motivation: wrapping the `StudyCard` via `withPermissions` causes the former to render slowly, because `withPermissions` defers rendering the `StudyCard` until the permissions have been fetched.)
3. Eliminates some related (and unnecessary) `/permissions` service calls on page load.

**Some more details about the race condition**

The “race” is between the `DataRestrictionDaemon`, which dispatches a redux action to clear the modal every time the route’s pathname changes, and various `attemptAction`s which are executed when certain “pages” are loaded (and which, on action denial, dispatch a redux action to show the modal).

Under normal circumstances, the former will always happen before the latter, but in `web-eda` local dev, it's possible to make the latter happen before the former. (For example, hit “reload” when on a `ResrictedPage` for which you don’t have access. The page contents will [correctly] be blurred, but the modal will not appear.)

The culprit is that the `DataRestrictionDaemon` is wrapped in `withPermissions`, which defers rendering the wrapped component until the permissions are fetched.

This PR, and the companion PR for ClinEpiWebsite, resolves this issue by “asynchronously” retrieving the permissions for `DataRestrictionDaemon` using a hook within the daemon, instead of “synchronously” deferring the daemon’s rendering until the permissions are fetched. Doing so will cause the modal-clearing-action to be dispatched immediately.