### PR TITLE
FetchClient: if a response has no body, pass undefined to transformResponse

### DIFF
--- a/Client/src/util/api.ts
+++ b/Client/src/util/api.ts
@@ -122,10 +122,9 @@ export function createFetchApiRequestHandler(options: FetchApiOptions): ApiReque
     const response = await fetchApi(request);
     // TODO Make this behavior configurable
     if (response.ok) {
-      const responseBody = response.headers.get('Content-Type')?.startsWith('application/json')
-        ? await response.json()
-        : await response.text();
-        return await transformResponse(responseBody);
+      const responseBody = await fetchResponseBody(response);
+
+      return await transformResponse(responseBody);
     }
     throw new Error(`${response.status} ${response.statusText}${'\n'}${await response.text()}`);
   }
@@ -157,11 +156,20 @@ export abstract class FetchClient {
     const response = await fetchApi(request);
     // TODO Make this behavior configurable
     if (response.ok) {
-      const responseBody = response.headers.get('Content-Type')?.startsWith('application/json')
-        ? await response.json()
-        : await response.text();
-        return await transformResponse(responseBody);
+      const responseBody = await fetchResponseBody(response);
+
+      return await transformResponse(responseBody);
     }
     throw new Error(`${response.status} ${response.statusText}${'\n'}${await response.text()}`);
   }
+}
+
+async function fetchResponseBody(response: Response) {
+  const contentType = response.headers.get('Content-Type');
+
+  return contentType == null
+    ? undefined
+    : contentType.startsWith('application/json')
+    ? response.json()
+    : response.text();
 }


### PR DESCRIPTION
This is necessary to properly validate no-body responses with [io-ts](https://github.com/gcanti/io-ts). (Currently, `""` is passed to `transformResponse`, which violates [`voidType`](https://github.com/gcanti/io-ts/blob/master/index.md#implemented-types--combinators).)