### PR TITLE
Handle na versions in Source Versions summary

### DIFF
--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -59,7 +59,11 @@ function renderSourceVersion(version, newcategory) {
 function getSourceVersion(attributes, tables) {
   let version;
   if (attributes.newcategory === 'Genomes') {
-    version = attributes.functional_annotation_version ? attributes.genome_version + ", " + attributes.annotation_version + ", " + attributes.functional_annotation_version : attributes.genome_version + ", " + attributes.annotation_version;
+    g_version = attributes.genome_version ? attributes.genome_version : "n/a";
+    a_version = attributes.annotation_version ? attributes.annotation_version : "n/a";
+    fa_version = attributes.functional_annotation_version ? attributes.functional_annotation_version : "n/a";
+    
+    version = g_version + ", " + a_version + ", " + fa_version;
   } else {
     version = tables.Version && tables.Version[0];
   }

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -38,8 +38,9 @@ function renderSourceVersion(version, newcategory) {
       <span>
         {version}&nbsp;
         <i className="fa fa-question-circle" style={{ color: 'blue' }}
-        title={'The source versions from' +
-        ' the site the data was acquired.'}/>
+        title={'The source versions for the assembly, ' +
+               'structural annotation and functional annotation.  ' + 
+               'See the Data Set Release History table for more details.'}/>
       </span>
     );
   } else {

--- a/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/Client/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -59,9 +59,9 @@ function renderSourceVersion(version, newcategory) {
 function getSourceVersion(attributes, tables) {
   let version;
   if (attributes.newcategory === 'Genomes') {
-    g_version = attributes.genome_version ? attributes.genome_version : "n/a";
-    a_version = attributes.annotation_version ? attributes.annotation_version : "n/a";
-    fa_version = attributes.functional_annotation_version ? attributes.functional_annotation_version : "n/a";
+    let g_version = attributes.genome_version ? attributes.genome_version : "n/a";
+    let a_version = attributes.annotation_version ? attributes.annotation_version : "n/a";
+    let fa_version = attributes.functional_annotation_version ? attributes.functional_annotation_version : "n/a";
     
     version = g_version + ", " + a_version + ", " + fa_version;
   } else {


### PR DESCRIPTION
Based on a conversation with Susanne. 

For genome datasets, the record page summary has a Source Version(s) line that shows the latest version for the genome version, structural annotation version, and functional annotation version. This PR updates the line by adding "n/a" if the version is null, and improves the help text.