### PR TITLE
Prepare for building from NPM

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -33,7 +33,7 @@
     "whatwg-fetch": "^3.5.0"
   },
   "peerDependencies": {
-    "@veupathdb/wdk-client": "alpha"
+    "@veupathdb/wdk-client": ">=0.5.4"
   },
   "devDependencies": {
     "@types/node": "^14.14.7",

--- a/Client/package.json
+++ b/Client/package.json
@@ -26,8 +26,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@veupathdb/components": "^0.11.8",
-    "@veupathdb/eda": "^1.1.46",
+    "@veupathdb/components": "^0.11.10",
+    "@veupathdb/eda": "^1.1.50",
     "custom-event-polyfill": "^1.0.7",
     "md5": "^2.3.0",
     "whatwg-fetch": "^3.5.0"
@@ -39,7 +39,7 @@
     "@types/node": "^14.14.7",
     "@types/shelljs": "^0.8.8",
     "@veupathdb/react-scripts": "^1.2.0",
-    "@veupathdb/wdk-client": "^0.5.2",
+    "@veupathdb/wdk-client": "^0.5.4",
     "bubleify": "^2.0.0",
     "icon-font-generator": "^2.1.11",
     "ify-loader": "^1.1.0",

--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -1235,6 +1235,46 @@
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
+"@veupathdb/components@^0.11.10":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.10.tgz#3f88b3dac73d0fa98dcf2de56f3f16c2a55c3bc5"
+  integrity sha512-7jI10uRxWpezGVUwGuFiHBEYBOAunm8BGelpbn86kWr8JljZs9hC6LmNtbLrCkUGnj9wFjBVYa4wbsjKJi1RXA==
+  dependencies:
+    "@emotion/react" "^11.7.0"
+    "@material-ui/core" "^4.11.2"
+    "@material-ui/icons" "^4.11.2"
+    "@material-ui/lab" "^4.0.0-alpha.57"
+    "@types/d3" "^7.1.0"
+    "@types/date-arithmetic" "^4.1.1"
+    "@veupathdb/core-components" "^0.4.0"
+    "@visx/gradient" "^1.0.0"
+    "@visx/group" "^1.0.0"
+    "@visx/hierarchy" "^1.0.0"
+    "@visx/shape" "^1.4.0"
+    "@visx/text" "^1.3.0"
+    "@visx/tooltip" "^1.3.0"
+    "@visx/visx" "^1.1.0"
+    bootstrap "^4.5.2"
+    color-math "^1.1.3"
+    d3 "^7.1.1"
+    date-arithmetic "^4.1.0"
+    debounce-promise "^3.1.2"
+    latlon-geohash "^2.0.0"
+    leaflet "^1.6.0"
+    leaflet-drift-marker "^1.0.3"
+    luxon "^1.25.0"
+    plotly.js "^2.6.0"
+    re-resizable "^6.9.0"
+    react "^16.13.1"
+    react-bootstrap "^1.3.0"
+    react-cool-dimensions "^1.1.11"
+    react-dom "^16.13.1"
+    react-html-parser "^2.0.2"
+    react-leaflet "^2.7.0"
+    react-plotly.js "^2.4.0"
+    react-transition-group "^4.4.1"
+    shape2geohash "^1.2.5"
+
 "@veupathdb/components@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.8.tgz#4c843309cfa835c41a8be3821801cf9a99ff78e6"
@@ -1287,10 +1327,10 @@
     react-modal "^3.14.3"
     react-table "^7.7.0"
 
-"@veupathdb/eda@^1.1.46":
-  version "1.1.46"
-  resolved "https://registry.yarnpkg.com/@veupathdb/eda/-/eda-1.1.46.tgz#28b502a158c1b4c6e19a1e0af768d4d4feba548e"
-  integrity sha512-uo+fM7P69F2tSeQ+D0nqQN0TOKzSagNll88UAwsc+wv34GBsvbZU4cE0w85PxtROxgI2Jad4WyLFpxvmVrb3Zg==
+"@veupathdb/eda@^1.1.50":
+  version "1.1.50"
+  resolved "https://registry.yarnpkg.com/@veupathdb/eda/-/eda-1.1.50.tgz#d4052934688c7f4d6c31863e78378aa1e168ba77"
+  integrity sha512-HZl5ut/ug/YGv3gqGL7MXKicO2Cx30b9t5tTaJendAOiopqN04qAUlNAYVUQD49gTkgeZ0wf9wV9U8ZBa98eUg==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"
@@ -1298,11 +1338,10 @@
     "@material-ui/icons" "^4.11.2"
     "@material-ui/lab" "^4.0.0-alpha.58"
     "@types/debounce-promise" "^3.1.3"
-    "@veupathdb/components" "^0.11.8"
+    "@veupathdb/components" "^0.11.10"
     "@veupathdb/core-components" "^0.4.1"
     "@veupathdb/http-utils" "^1.0.1"
-    "@veupathdb/study-data-access" "^0.1.3"
-    "@veupathdb/wdk-client" "^0.5.2"
+    "@veupathdb/study-data-access" "^0.1.5"
     debounce-promise "^3.1.2"
     file-saver "^2.0.5"
     fp-ts "^2.9.3"
@@ -1338,21 +1377,20 @@
     read "^1.0.7"
     set-cookie-parser "^2.4.6"
 
-"@veupathdb/study-data-access@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.1.3.tgz#e9f7d97cf96a35dc4930a482202eeec55ef0cbe5"
-  integrity sha512-NxQqA/xvqWSzvITDmxQ3JvtBk1l1xWVeFbC09yfBoGTYwHoP6wmDBs+huJhyPLxZkPymytYcpg5ZAJga35LiVg==
+"@veupathdb/study-data-access@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.1.5.tgz#8f0aae7c4c35f001b8f3bff77feeeba3c86df578"
+  integrity sha512-CPoQ03Hg8O35JaAbhx0g22eAHOaDQ14pvydjMEs1oYFQggw6+cckp6tEpOCHhbAlwIBn0rvSdntGeJho2iLY/w==
   dependencies:
     "@veupathdb/http-utils" "^1.0.1"
-    "@veupathdb/wdk-client" "^0.5.2"
     fp-ts "^2.11.5"
     io-ts "^2.2.16"
     lodash "^4.17.21"
 
-"@veupathdb/wdk-client@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.5.2.tgz#3569fc7d0c58a815f5f8fa594ab5e69a3f328549"
-  integrity sha512-BI0hWSnlPeN4NrKh9UGN7PKqBqf2Ghdad9uzUz+Ba2Po6QTRHDZj70u1VJS2NmjoQxCzyuOXOprRKQIXdBGkeg==
+"@veupathdb/wdk-client@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.5.4.tgz#a4e2ecfdaf66f8f6f02fab82c273b120a608fe86"
+  integrity sha512-pEIVIPDvNs8kBJhBen97lT9ixqgDzbjYeYjmvCkM5u5Q3SRLXl5DNs2o0yCkVJBynXSUHbOUg2me3VqsKAGXHw==
   dependencies:
     "@types/datatables.net" "^1.10.5"
     "@types/flot" "^0.0.31"


### PR DESCRIPTION
This PR upgrades @veupathdb/components, @veupathdb/eda, and @veupathdb/wdk-client (peer/dev dependency). In particular, the upgrade of @veupathdb/eda eliminates a transitive dependency of @veupathdb/wdk-client.