### PR TITLE
Build from npm

### DIFF
--- a/Site/site.webpack.config.js
+++ b/Site/site.webpack.config.js
@@ -1,4 +1,3 @@
-var path = require('path');
 var baseConfig = require('../../install/base.webpack.config');
 
 // Create webpack alias configuration object

--- a/Site/site.webpack.config.js
+++ b/Site/site.webpack.config.js
@@ -26,7 +26,8 @@ module.exports = function configure(additionalConfig) {
           use: 'source-map-loader'
         },
         {
-          test: /node_modules/,
+          test: /\.(js|jsx|ts|tsx)$/,
+          include: /node_modules/,
           loader: 'ify-loader'
         }
       ]

--- a/Site/site.webpack.config.js
+++ b/Site/site.webpack.config.js
@@ -4,8 +4,6 @@ var baseConfig = require('../../install/base.webpack.config');
 // Create webpack alias configuration object
 var alias = {
   site: process.cwd() + '/webapp',
-  '@veupathdb/wdk-client': path.resolve(__dirname, '../../WDKClient/Client'),
-  '@veupathdb/web-common': path.resolve(__dirname, '../../EbrcWebsiteCommon/Client'),
 };
 
 module.exports = function configure(additionalConfig) {

--- a/Site/site.webpack.config.js
+++ b/Site/site.webpack.config.js
@@ -11,10 +11,10 @@ module.exports = function configure(additionalConfig) {
     context: process.cwd(),
     resolve: {
       alias,
-      modules: [ path.resolve(__dirname, '../../EbrcWebsiteCommon/Client/node_modules'), 'node_modules', ]
+      modules: [ 'node_modules', ]
     },
     resolveLoader: {
-      modules: [ path.resolve(__dirname, '../../EbrcWebsiteCommon/Client/node_modules'), 'node_modules', ]
+      modules: [ 'node_modules', ]
     },
 
     module: {

--- a/build.xml
+++ b/build.xml
@@ -106,7 +106,6 @@
   <target name="eupathWebComponentInstall">
     <echo message="Building ${project}/${component} assets"/>
     <ant target="defaultWebComponentInstall"/>
-    <ant target="copyClientImages"/>
     <ant target="siteLog4j"/>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -104,7 +104,6 @@
 
   <!-- Target to be used by implementing sites -->
   <target name="eupathWebComponentInstall">
-    <antcall target="buildLocalNpmPackages"/>
     <echo message="Building ${project}/${component} assets"/>
     <ant target="defaultWebComponentInstall"/>
     <ant target="copyClientImages"/>


### PR DESCRIPTION
Co-depends on https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/84, https://github.com/VEuPathDB/ApiCommonWebsite/pull/33, https://github.com/VEuPathDB/ClinEpiWebsite/pull/14, https://github.com/VEuPathDB/MicrobiomeWebsite/pull/22, and https://github.com/VEuPathDB/OrthoMCLClient/pull/29.

This PR reintroduces building WDK sites from @veupathdb/wdk-client and @veupathdb/web-common npm assets.