### PR TITLE
Upgrade eda study cards

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@veupathdb/components": "^0.11.13",
+    "@veupathdb/core-components": "^0.9.1",
     "@veupathdb/eda": "^1.3.0",
     "custom-event-polyfill": "^1.0.7",
     "md5": "^2.3.0",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.7",
+    "@types/react-table": "^7.7.9",
     "@types/shelljs": "^0.8.8",
     "@veupathdb/react-scripts": "^1.2.0",
     "@veupathdb/wdk-client": "^0.5.4",

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -8,7 +8,11 @@ import DownloadLink from './DownloadLink';
 import { isPrereleaseStudy } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 import './StudyCard.scss';
 import { makeEdaRoute } from 'ebrc-client/routes';
-
+import { colors } from '@veupathdb/core-components';
+import Card from '@veupathdb/core-components/dist/components/containers/Card';
+import { TableDownload, EdaIcon } from '@veupathdb/core-components/dist/components/icons';
+import FilledButton from '@veupathdb/core-components/dist/components/buttons/FilledButton';
+import OutlinedButton from '@veupathdb/core-components/dist/components/buttons/OutlinedButton';
 
 class StudyCard extends React.Component {
   constructor (props) {
@@ -28,95 +32,50 @@ class StudyCard extends React.Component {
   }
 
   renderLinkouts() {
-    const { analyses, attemptAction, card } = this.props;
-    if (useEda) {
-      return (
-        <div className="StudyCard-LinkOuts">
-         {// <DownloadLink className="box StudyCard-Download" linkText="Download" iconFirst studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
-          }
-          {analyses?.some(analysis => analysis.studyId === card.id) &&
-            <div className="box StudyCard-MyAnalyses">
-              <Link to={{ pathname: makeEdaRoute(), search: `?s=${encodeURIComponent(card.name)}` }}>
-                <i className="ebrc-icon-table"/> My analyses
-              </Link>
-            </div>
-          }
-        </div>
-      );
-    }
-    else {
-      return (
-        <DownloadLink className="box StudyCard-Download" linkText="Download Data" studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
-      );
-    }
+    const { attemptAction, card } = this.props;
+    return (
+      <DownloadLink className="box StudyCard-Download" linkText="Download Data" studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
+    );
   }
 
   renderFooter() {
     const { card, user, permissions } = this.props;
-    if (useEda) {
-      const { disabled } = card;
-      const edaRoute = makeEdaRoute(card.id) + '/~latest';
-      return (
-        <Link className="StudyCard-SearchLink" to={edaRoute}>
-          <div className="box StudyCard-PreFooter">
-            { isPrereleaseStudy(card.access, card.id, user, permissions)
-              ? <span title="Please check the study page">Coming Soon!</span>
-              : <span>{disabled ? 'Explore Unavailable' : 'Explore The Data'}</span>
-            }
-          </div>
-          <div className="box StudyCard-Footer">
-            { (!isPrereleaseStudy(card.access, card.id, user, permissions))
-             ? (
-               <div className="box">
-                 <i className="ebrc-icon-edaIcon"/>
-               </div>
-             ) : (
-               <div className="emptybox">
-                 &nbsp;
-               </div>
-             )}
-          </div>
-        </Link>
-      );
-    }
-    else {
-      const { searchType } = this.state;
-      const { searches, disabled } = card;
-      return (
-        <>
-          <div className="box StudyCard-PreFooter">
-            { isPrereleaseStudy(card.access, card.id, user, permissions)
-              ? <span title="Please check the study page">Coming Soon!</span>
-              : searchType
-                ? <span>by <b>{searchType}</b></span>
-                : <span title="Click on an Icon">{disabled ? 'Explore Unavailable' : 'Explore The Data'}</span>
-            }
-          </div>
-          <div className="box StudyCard-Footer">
-            { (!isPrereleaseStudy(card.access, card.id, user, permissions) && searches.length)
-              ? searches.map(({ icon, displayName, path }) => {
-                  const route = `/search/${path}`;
-                  return (
-                    <div
-                      key={path}
-                      className="box"
-                      onMouseEnter={() => this.displaySearchType(displayName)}
-                      onMouseLeave={this.clearDisplaySearchType}>
-                      <Link className="StudyCard-SearchLink" to={route}>
-                        <i className={icon} />
-                      </Link>
-                    </div>
-                  );
-                })
-              : (
-                <div className="emptybox">
-                  &nbsp;
-                </div>
-              )}
-          </div>
-        </>
-      );
-    }
+    const { searchType } = this.state;
+    const { searches, disabled } = card;
+    return (
+      <>
+        <div className="box StudyCard-PreFooter">
+          { isPrereleaseStudy(card.access, card.id, user, permissions)
+            ? <span title="Please check the study page">Coming Soon!</span>
+            : searchType
+              ? <span>by <b>{searchType}</b></span>
+              : <span title="Click on an Icon">{disabled ? 'Explore Unavailable' : 'Explore The Data'}</span>
+          }
+        </div>
+        <div className="box StudyCard-Footer">
+          { (!isPrereleaseStudy(card.access, card.id, user, permissions) && searches.length)
+            ? searches.map(({ icon, displayName, path }) => {
+                const route = `/search/${path}`;
+                return (
+                  <div
+                    key={path}
+                    className="box"
+                    onMouseEnter={() => this.displaySearchType(displayName)}
+                    onMouseLeave={this.clearDisplaySearchType}>
+                    <Link className="StudyCard-SearchLink" to={route}>
+                      <i className={icon} />
+                    </Link>
+                  </div>
+                );
+              })
+            : (
+              <div className="emptybox">
+                &nbsp;
+              </div>
+            )}
+        </div>
+      </>
+    );
   }
 
   render () {
@@ -124,35 +83,106 @@ class StudyCard extends React.Component {
     const { id, name, categories, route, headline, points, disabled } = card;
     const myStudyTitle = "Go to the Study Details page";
     const primaryCategory = categories[0];
-    const edaRoute = makeEdaRoute(card.id) + '/~latest';
+    const edaRoute = makeEdaRoute(card.id) + '/new';
 
-    return (
-      <div className={'Card StudyCard ' + (disabled ? 'disabled' : '') + ' StudyCard__' + id}>
-        <div className="box StudyCard-Heading">
-          <h2 title={myStudyTitle}><Link to={useEda ? edaRoute + '/details' : route}>{safeHtml(name)}</Link></h2>
-          <div className="box StudyCard-Categories">
-            {primaryCategory && <CategoryIcon category={primaryCategory}/>}
+
+    if (useEda) {
+      const styleOverrides = {content: {
+          backgroundColor: 'white'
+        },
+        border: {
+          color: "#c6dee2"
+        }};
+
+      const exploreOnPress = function () {
+        location.href = edaRoute;
+      };
+      const myAnalysesOnPress = function () {
+        return ({ "pathname": makeEdaRoute(), "search": `?s=${encodeURIComponent(card.name)}` });
+      };
+
+      const { analyses, attemptAction, card, user, permissions } = this.props;
+
+      const studyYears = headline.match(/[0-9]{4}-?,?\s?[0-9]{4}/) 
+                          ? headline.match(/[0-9]{4}-?,?\s?[0-9]{4}/)[0] 
+                          : headline.match(/[0-9]{4}/) 
+                            ? headline.match(/[0-9]{4}/)[0]
+                            : '';
+
+      const studyLocation = headline.replace(/[0-9]{4}-?,?\s?/g,'').replace(/\s?from\s?$|\s?in\s?$/,'').replace(/,\s?$/,'').trim();
+      const disabledStyle = {opacity: 0.3,
+        pointerEvents: 'none',
+        transition: 'all 0.5s'
+      };
+
+      return (
+          <div style={disabled ? {minWidth: 300, margin: 10, ...disabledStyle} : {minWidth: 300, margin: 10}}>
+            <Card title={safeHtml(name)} titleSize="small" width={300} height={450} themeRole="primary" styleOverrides={styleOverrides}>
+              <div style={{fontSize: "0.8rem"}}>
+               <div style={{marginTop: 20, color: colors.gray[800]}}>
+                <div style={{display: 'flex', alignItems: 'center', margin: 3}}>
+                  <span style={{ fontWeight: 600}}>Location:</span>
+                  &nbsp;{studyLocation}
+                </div>
+                {studyYears && (<div style={{display: 'flex', alignItems: 'center', margin: 3}}>
+                  <span style={{ fontWeight: 600}}>Dates:</span>
+                  &nbsp;{studyYears}
+                  </div>)
+                }
+                </div>
+                <div className="emptybox">
+                  &nbsp;
+                </div>
+                <div style={{marginTop: 10, color: colors.gray[700]}}>
+                  <ul>
+                    {points.map((point, index) => <li style={{marginTop: 5}} key={index} dangerouslySetInnerHTML={{ __html: point }} />)}
+                  </ul>
+                </div>
+               </div>
+                <div style={{position: 'absolute', bottom: 30, display: 'flex', flexFlow: 'row', gap: 13, width: 240}}>
+                  { isPrereleaseStudy(card.access, card.id, user, permissions)
+                    ? <FilledButton text="Coming soon!" icon={EdaIcon} size="small" themeRole="primary" />
+                    : <Link to={edaRoute} style={{textDecoration: 'none'}}><FilledButton text={disabled ? 'Explore Unavailable' : 'Explore'} textTransform="none" icon={EdaIcon} size="small" themeRole="primary"/></Link>
+                  }
+                  {analyses?.some(analysis => analysis.studyId === card.id) &&
+                    <Link to={{ pathname: makeEdaRoute(), search: `?s=${encodeURIComponent(card.name)}` }} style={{textDecoration: 'none'}}><OutlinedButton text="My analyses" textTransform="none" icon={TableDownload} size="small" themeRole="primary"/></Link>
+                  }
+                </div>
+            </Card>  
+        </div>
+      );
+
+    } else {
+
+      return (
+        <div className={'Card StudyCard ' + (disabled ? 'disabled' : '') + ' StudyCard__' + id}>
+          <div className="box StudyCard-Heading">
+            <h2 title={myStudyTitle}><Link to={route}>{safeHtml(name)}</Link></h2>
+            <div className="box StudyCard-Categories">
+              {primaryCategory && <CategoryIcon category={primaryCategory}/>}
+            </div>
+            {/*<Link to={route} target="_blank" title={myStudyTitle}>
+              <Icon fa="angle-double-right" /> 
+            </Link> */}
           </div>
-          {/*<Link to={route} target="_blank" title={myStudyTitle}>
-            <Icon fa="angle-double-right" /> 
-          </Link> */}
+          <Link to={route} className="StudyCard-DetailsLink" title={myStudyTitle}>
+            <small>Study Details <Icon fa="chevron-circle-right"/></small>
+          </Link>
+          <div className="box StudyCard-Stripe">
+            {headline}
+          </div>
+          <div className="box StudyCard-Body">
+            <ul>
+              {points.map((point, index) => <li key={index} dangerouslySetInnerHTML={{ __html: point }} />)}
+           </ul>
+          </div>
+          {this.renderLinkouts()}
+          {this.renderFooter()}
         </div>
-        <Link to={useEda ? edaRoute + '/details' : route} className="StudyCard-DetailsLink" title={myStudyTitle}>
-          <small>Study Details <Icon fa="chevron-circle-right"/></small>
-        </Link>
-        <div className="box StudyCard-Stripe">
-          {headline}
-        </div>
-        <div className="box StudyCard-Body">
-          <ul>
-            {points.map((point, index) => <li key={index} dangerouslySetInnerHTML={{ __html: point }} />)}
-          </ul>
-        </div>
-        {this.renderLinkouts()}
-        {this.renderFooter()}
-      </div>
-    );
+      );
+    }
   }
 }
 
 export default connect( state => ({user: state.globalData.user}) )(StudyCard);
+

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -85,24 +85,25 @@ class StudyCard extends React.Component {
     const primaryCategory = categories[0];
     const edaRoute = makeEdaRoute(card.id) + '/new';
 
-
     if (useEda) {
+
+      // Style overrides for Card
       const styleOverrides = {content: {
           backgroundColor: 'white'
         },
         border: {
           color: "#c6dee2"
         }};
-
-      const exploreOnPress = function () {
-        location.href = edaRoute;
+        
+      const disabledStyle = {opacity: 0.3,
+        pointerEvents: 'none',
+        transition: 'all 0.5s'
       };
-      const myAnalysesOnPress = function () {
-        return ({ "pathname": makeEdaRoute(), "search": `?s=${encodeURIComponent(card.name)}` });
-      };
-
+      
       const { analyses, attemptAction, card, user, permissions } = this.props;
 
+      // Break headline into study years and location. This is a temporary solution - will be replaced by the presenter
+      // file reorganization in the spring
       const studyYears = headline.match(/[0-9]{4}-?,?\s?[0-9]{4}/) 
                           ? headline.match(/[0-9]{4}-?,?\s?[0-9]{4}/)[0] 
                           : headline.match(/[0-9]{4}/) 
@@ -110,10 +111,6 @@ class StudyCard extends React.Component {
                             : '';
 
       const studyLocation = headline.replace(/[0-9]{4}-?,?\s?/g,'').replace(/\s?from\s?$|\s?in\s?$/,'').replace(/,\s?$/,'').trim();
-      const disabledStyle = {opacity: 0.3,
-        pointerEvents: 'none',
-        transition: 'all 0.5s'
-      };
 
       return (
           <div style={disabled ? {minWidth: 300, margin: 10, ...disabledStyle} : {minWidth: 300, margin: 10}}>

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -1172,6 +1172,13 @@
     "@types/react-dom" "*"
     "@types/react-transition-group" "*"
 
+"@types/react-table@^7.7.9":
+  version "7.7.9"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.9.tgz#ea82875775fc6ee71a28408dcc039396ae067c92"
+  integrity sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@*", "@types/react-transition-group@^4.2.0", "@types/react-transition-group@^4.4.1":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
@@ -1331,6 +1338,18 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@veupathdb/core-components/-/core-components-0.8.1.tgz#5ac32c9ab097024ee4dc25a08e4dca8d5771d63d"
   integrity sha512-1FRse8MDZkODFYqvY1HjWhF0NlNedHdgtVpl+MiAHKov6Dgm/UjWK4nMjWvfbo/fJQdINMXDmO9nlbSkpf7dIA==
+  dependencies:
+    "@material-ui/core" "^4.12.3"
+    "@material-ui/icons" "^4.11.2"
+    lodash "^4.17.21"
+    react-cool-dimensions "^2.0.7"
+    react-modal "^3.14.3"
+    react-table "^7.7.0"
+
+"@veupathdb/core-components@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@veupathdb/core-components/-/core-components-0.9.1.tgz#2cf12b9b5e30da579195110523b4466a4d5aafdf"
+  integrity sha512-AIc3q9vPIDI21rR4mNs2l11kmvFKe/3M3lexJZO+wR+6auhCDphRrPDPqpPScNqLwFL04uBZ6fDDcFIh8IPlVg==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Addresses web-eda [768](https://github.com/VEuPathDB/web-eda/issues/768).

## Changes
This PR contains two important changes:
1. implements the new `Card` component from the `core-components` library. 
2. Changes the "Explore" button route to create a new analysis instead of going to the latest analysis


## Additional To Dos
The style of the cards has not been approved. I've listed the concerns I know about below and a bit of my thoughts. In addition, @eikonomega is working on some changes to `Card` that we will want to incorporate once complete.
- [ ] The headline (Location, Dates) is not visually appealing. I tried breaking the lines but that created too much white space. I considered centering them in the card but then we'd have different widths of these headlines which may look funny. Open to ideas!!
- [ ] There is a concern with it being unclear that the user can horizontally scroll through the cards. The suggested solutions were to 1. increase the card corner radius or 2. add a drop shadow to the cards. I am not a fan of 1. because the corner radius is consistent with other components in the design system. Idea 2. may be fine, but we need to wait until the `Card` border problems are solved (see slack styling wg messages) because we place the drop shadow on the enclosing div, which then acts funky with the border. Anyways, Mike's border fix will mean we can remove my border color in the card (lines 94-96) and add a drop shadow.

<img width="439" alt="Screen Shot 2022-02-04 at 10 45 29 AM" src="https://user-images.githubusercontent.com/11710234/152558743-c2810d54-763a-41ae-9487-5888e8f12e4e.png">

- [ ] Use a minimum title box height. See core-components issue [#31](https://github.com/VEuPathDB/core-components/issues/31)


## Notes and questions:
- After presenter updating in b57 or later, we will no longer need the ugly regex
- I really struggled with having the buttons send the user to the correct location. I tried pass a function that updated `window.location.href` to `onPress`, and I also tried getting the `history` hook to work but that didn't work because `StudyCard` is not a function component. Wrapping the buttons in `Link` was unfortunately the only way I could get it to work :( Please let me know if there's a better way to do this!