### PR TITLE
eupathWebComponentInstall: copy the image assets of @veupathdb/web-co…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -106,6 +106,7 @@
   <target name="eupathWebComponentInstall">
     <echo message="Building ${project}/${component} assets"/>
     <ant target="defaultWebComponentInstall"/>
+    <ant target="copyClientImages"/>
     <ant target="siteLog4j"/>
   </target>
 
@@ -124,7 +125,7 @@
 
   <target name="copyClientImages">
     <copy todir="${webappTargetDir}/images">
-      <fileset dir="${projectsDir}/EbrcWebsiteCommon/Client/images"/>
+      <fileset dir="${projectsDir}/${project}/${component}/node_modules/@veupathdb/web-common/images"/>
     </copy>
   </target>
 


### PR DESCRIPTION
…mmon to the webapp

This PR updates (and re-incorporates) the `copyClientImages` ant task which is invoked by `eupathWebComponentInstall`. Now, the image assets are copied from the site repo's installation of  `@veupathdb/web-common` in `node_modules`.

(Of note: a more robust solution would be to obtain the path to `@veupathdb/web-common` via node's native [require.resolve](https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules). An even better solution would be to update our legacy client code [such as the OAuth client] to support npm imports.)