### PR TITLE
eupathWebComponentInstall: Only copyClientImages for "yarn" GUS compo…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -106,6 +106,9 @@
   <target name="eupathWebComponentInstall">
     <echo message="Building ${project}/${component} assets"/>
     <ant target="defaultWebComponentInstall"/>
+    <antcall target="copyClientImages">
+      <param name="yarnCwd" value="${projectsDir}/${project}/${component}"/>
+    </antcall>
     <ant target="siteLog4j"/>
   </target>
 
@@ -122,9 +125,9 @@
     </exec>
   </target>
 
-  <target name="copyClientImages">
+  <target name="copyClientImages" if="isYarnComponent" depends="checkIfYarnComponent">
     <copy todir="${webappTargetDir}/images">
-      <fileset dir="${projectsDir}/EbrcWebsiteCommon/Client/images"/>
+      <fileset dir="${yarnCwd}/node_modules/@veupathdb/web-common/images"/>
     </copy>
   </target>
 


### PR DESCRIPTION
…nents

This PR fixes a bug with https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/95 which was causing the [web installation](https://github.com/VEuPathDB/OrthoMCLService/blob/master/build.xml#L45-L52) of the [OrthoMCLService/Service GUS component](https://github.com/VEuPathDB/OrthoMCLService/tree/master/Service) to fail.

Now, `copyClientImages` is only performed for "yarn" GUS components. 