### PR TITLE
set user.properties.skipStudyPermissions for eda and non-eda differently

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/wrapWdkService.js
+++ b/Client/src/wrapWdkService.js
@@ -27,8 +27,8 @@ export default wdkService => ({
     method: 'get',
     path: '/site-messages'
   }),
-  getUser: () => {
-    let user = wdkService.getCurrentUser();
+  getCurrentUser: async () => {
+    let user = await wdkService.getCurrentUser();
     if (useEda) {
       user.properties.skipStudyPermissions = false;
     } else {

--- a/Client/src/wrapWdkService.js
+++ b/Client/src/wrapWdkService.js
@@ -26,5 +26,14 @@ export default wdkService => ({
     useCache: false,
     method: 'get',
     path: '/site-messages'
-  })
+  }),
+  getUser: () => {
+    let user = wdkService.getCurrentUser();
+    if (useEda) {
+      user.properties.skipStudyPermissions = false;
+    } else {
+      user.properties.skipStudyPermissions = true;
+    }
+    return user;
+  }
 });

--- a/Client/src/wrapWdkService.js
+++ b/Client/src/wrapWdkService.js
@@ -29,11 +29,7 @@ export default wdkService => ({
   }),
   getCurrentUser: async () => {
     let user = await wdkService.getCurrentUser();
-    if (useEda) {
-      user.properties.skipStudyPermissions = false;
-    } else {
-      user.properties.skipStudyPermissions = true;
-    }
+    user.properties.skipStudyPermissions = !useEda;
     return user;
   }
 });


### PR DESCRIPTION
We'd like to have eda sites check permissions, while non-eda sites (currently live microbiome) skip this permissions check.

Related to a discussion in [web-study-data-access](https://github.com/VEuPathDB/web-study-data-access/pull/8)

Tested on my mbio site with live site setup. No failures :) Working on getting the eda version of the dev site tested.

I'm not confident this is the right spot for the change? I know `wdkService` comes in with a `getCurrentUser` method but no `getUser` method. I also have seen `wdkService.getUser` implemented elsewhere so it must get that method sometime. Looking forward to your feedback!