### PR TITLE
Remove unnecessary permissions checks and upgrade eda packages

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/package.json
+++ b/Client/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@veupathdb/components": "^0.11.23",
-    "@veupathdb/eda": "^1.7.8",
+    "@veupathdb/eda": "^1.8.3",
     "custom-event-polyfill": "^1.0.7",
     "md5": "^2.3.0",
     "whatwg-fetch": "^3.5.0"

--- a/Client/src/App/Showcase/Showcase.jsx
+++ b/Client/src/App/Showcase/Showcase.jsx
@@ -86,7 +86,7 @@ export default function Showcase(props) {
           attemptAction={attemptAction}
           additionalClassName={contentType}
           renderCard={(card) =>
-            <Card analyses={analyses} card={card} attemptAction={attemptAction} prefix={prefix} key={card.name} />
+            <Card analyses={analyses} card={card} attemptAction={attemptAction} prefix={prefix} key={card.name} permissions={permissions}/>
           }
         />
       </div>

--- a/Client/src/App/Studies/DownloadLink.jsx
+++ b/Client/src/App/Studies/DownloadLink.jsx
@@ -47,5 +47,4 @@ function DownloadLink(props) {
 // attemptAction gets bound to the store, the store receives the action, which will get executed when user clicks.
 export default compose(
   wrappable,
-  connect(state => ({user: state.globalData.user}), { attemptAction })
-)(DownloadLink);
+  connect(null, { attemptAction }))(DownloadLink);

--- a/Client/src/App/Studies/DownloadLink.jsx
+++ b/Client/src/App/Studies/DownloadLink.jsx
@@ -9,11 +9,11 @@ import { connect } from 'react-redux'
 import { isPrereleaseStudy } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 
 function DownloadLink(props) {
-  const { attemptAction, studyAccess, studyId, studyUrl, user, permissions, className, linkText = '', iconFirst = false } = props;
+  const { attemptAction, studyAccess, studyId, studyUrl, permissions, className, linkText = '', iconFirst = false } = props;
   const myDownloadTitle = "Download data files";
   return (
     <div className={className}> 
-      { !isPrereleaseStudy(studyAccess, studyId, user, permissions)
+      { !isPrereleaseStudy(studyAccess, studyId, permissions)
         ? <Mesa.AnchoredTooltip
         fadeOut
         content={myDownloadTitle}>

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -155,4 +155,4 @@ class StudyCard extends React.Component {
   }
 }
 
-export default connect( state => ({user: state.globalData.user}) )(StudyCard);
+export default StudyCard;

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -52,20 +52,20 @@ class StudyCard extends React.Component {
   }
 
   renderFooter() {
-    const { card, user, permissions } = this.props;
+    const { card, permissions } = this.props;
     if (useEda) {
       const { disabled } = card;
       const edaRoute = makeEdaRoute(card.id) + '/new';
       return (
         <Link className="StudyCard-SearchLink" to={edaRoute}>
           <div className="box StudyCard-PreFooter">
-            { isPrereleaseStudy(card.access, card.id, user, permissions)
+            { isPrereleaseStudy(card.access, card.id, permissions)
               ? <span title="Please check the study page">Coming Soon!</span>
               : <span>{disabled ? 'Explore Unavailable' : 'Explore The Data'}</span>
             }
           </div>
           <div className="box StudyCard-Footer">
-            { (!isPrereleaseStudy(card.access, card.id, user, permissions))
+            { (!isPrereleaseStudy(card.access, card.id, permissions))
              ? (
                <div className="box">
                  <i className="ebrc-icon-edaIcon"/>
@@ -85,7 +85,7 @@ class StudyCard extends React.Component {
       return (
         <>
           <div className="box StudyCard-PreFooter">
-            { isPrereleaseStudy(card.access, card.id, user, permissions)
+            { isPrereleaseStudy(card.access, card.id, permissions)
               ? <span title="Please check the study page">Coming Soon!</span>
               : searchType
                 ? <span>by <b>{searchType}</b></span>
@@ -93,7 +93,7 @@ class StudyCard extends React.Component {
             }
           </div>
           <div className="box StudyCard-Footer">
-            { (!isPrereleaseStudy(card.access, card.id, user, permissions) && searches.length)
+            { (!isPrereleaseStudy(card.access, card.id, permissions) && searches.length)
               ? searches.map(({ icon, displayName, path }) => {
                   const route = `/search/${path}`;
                   return (

--- a/Client/src/App/Studies/StudyMenuItem.jsx
+++ b/Client/src/App/Studies/StudyMenuItem.jsx
@@ -39,7 +39,7 @@ class StudyMenuItem extends React.Component {
   }
 
   renderWdkMenuItem() {
-    const { study, user, permissions } = this.props;
+    const { study, permissions } = this.props;
     const { name, id, disabled, route, searches } = study;
     const SearchLink = this.renderSearchLink;
 
@@ -52,7 +52,7 @@ class StudyMenuItem extends React.Component {
           </Link>
         </div>
         <div className="row StudyMenuItem-Links">
-        { (!isPrereleaseStudy(study.access, study.id, user, permissions))
+        { (!isPrereleaseStudy(study.access, study.id, permissions))
           ? searches.map(({ path, displayName, icon }) => <SearchLink key={path} path={path} displayName={displayName} icon={icon} />)
           : (
             <div className="prerelease">
@@ -66,7 +66,7 @@ class StudyMenuItem extends React.Component {
   }
 
   renderEdaMenuItem() {
-    const { study, user, permissions } = this.props;
+    const { study, permissions } = this.props;
     const { name, id, disabled } = study;
     const edaRoute = makeEdaRoute(study.id) + '/new';
 
@@ -79,7 +79,7 @@ class StudyMenuItem extends React.Component {
         </div>
         <div className="row StudyMenuItem-Links">
         {
-          isPrereleaseStudy(study.access, study.id, user, permissions) &&
+          isPrereleaseStudy(study.access, study.id, permissions) &&
           <div className="prerelease">
             <small>(coming soon)</small>
           </div>

--- a/Client/src/App/Studies/StudyMenuItem.jsx
+++ b/Client/src/App/Studies/StudyMenuItem.jsx
@@ -94,5 +94,5 @@ class StudyMenuItem extends React.Component {
   }
 }
 
-export default connect( state => ({user: state.globalData.user}) )(StudyMenuItem);
+export default StudyMenuItem;
 

--- a/Client/src/component-wrappers/StudyAnswerController.jsx
+++ b/Client/src/component-wrappers/StudyAnswerController.jsx
@@ -12,7 +12,6 @@ import { useEda } from 'ebrc-client/config';
 
 // wrapping WDKClient AnswerController for specific rendering on certain columns
 function StudyAnswerController(props) {
-  const user = useSelector(state => state.globalData.user);
   const studyEntities = useSelector(state => state.studies && state.studies.entities);
 
   const { visibleRecords, totalCount } = useMemo(
@@ -50,7 +49,6 @@ function StudyAnswerController(props) {
     <React.Fragment>
       <props.DefaultComponent 
         {...props}
-        user={user}
         stateProps={{
           ...props.stateProps,
           records: visibleRecords,
@@ -144,7 +142,7 @@ const makeRenderCellContent = (permissions) => props => {
 function mapStateToProps(state,props) {
   const { record } = props;
   const { globalData, studies } = state;
-  const { siteConfig, user } = globalData;
+  const { siteConfig } = globalData;
   const { webAppUrl } = siteConfig;
 
   if (studies.loading) {
@@ -158,7 +156,7 @@ function mapStateToProps(state,props) {
   const study = get(studies, 'entities', [])
     .find(study => study.id === studyId);
 
-  return { study, webAppUrl, user };
+  return { study, webAppUrl };
 }
 
 export default StudyAnswerController;

--- a/Client/src/component-wrappers/StudyAnswerController.jsx
+++ b/Client/src/component-wrappers/StudyAnswerController.jsx
@@ -42,8 +42,8 @@ function StudyAnswerController(props) {
   );
 
   const renderCellContent = useMemo(
-    () => makeRenderCellContent(user, props.permissions),
-    [ user, props.permissions ]
+    () => makeRenderCellContent(props.permissions),
+    [ props.permissions ]
   );
 
   return (
@@ -85,11 +85,10 @@ interface RenderCellProps extends CellContentProps {
 }
 */
 
-const makeRenderCellContent = (user, permissions) => props => {
+const makeRenderCellContent = (permissions) => props => {
   const shouldRenderAsPrerelease = isPrereleaseStudy(
     props.record.attributes.study_access.toLowerCase(),
     props.record.attributes.dataset_id,
-    user,
     permissions
   );
 

--- a/Client/src/component-wrappers/StudyRecordHeading.jsx
+++ b/Client/src/component-wrappers/StudyRecordHeading.jsx
@@ -56,7 +56,7 @@ function StudyRecordHeading({
       {study != null && permissions != null && shouldOfferLinkToDashboard(permissions) && (
         <div className={cx('DashboardLink')}><Link className={'btn ' + cx('DashboardLink')} to={`/study-access/${study.id}`}>Data Access Dashboard</Link></div>
       )}
-      {study != null &&  showSearches && (!isPrereleaseStudy(study.access, study.id, user, permissions)) && (
+      {study != null &&  showSearches && (!isPrereleaseStudy(study.access, study.id, permissions)) && (
         <div className={cx()}>
           <div className={cx('Label')}>Search the data</div>
           {loading ? null :
@@ -71,20 +71,20 @@ function StudyRecordHeading({
           }
         </div>
       )}
-      {study != null && isPrereleaseStudy(study.access, study.id, user, permissions) && (
+      {study != null && isPrereleaseStudy(study.access, study.id, permissions) && (
         <div style={{backgroundColor:'lightblue',padding:'0.5em', fontSize:'1.8em',margin:'1.5em 0 0'}} className='record-page-banner'>
           This study has not yet been released. <span style={{fontSize:'80%'}}>
             For more information, please email {props.record.attributes.contact} at <a href={"mailto:" + study.email}>{study.email}</a>.</span>
         </div>
       )}
-      {study != null && isPrivateStudy(study.access, study.id, user, permissions) && (
+      {study != null && isPrivateStudy(study.access, study.id, permissions) && (
         <div style={{backgroundColor:'lightblue',padding:'0.5em', fontSize:'1.8em',margin:'1.5em 0 0'}} className='record-page-banner'>
           This study has data access restrictions. <span style={{fontSize:'80%'}}>
           Please <UserLink to={location.pathname + '/new'} user={user}>login</UserLink> or <UserLink user={user} to={requestAccessPath}>acquire research approval</UserLink> in order to search the data. The data from this study requires approval to download and use in research projects.
           </span>
         </div>
       )}
-      {study != null && showDownload && (!isPrereleaseStudy(study.access, study.id, user, permissions)) && (
+      {study != null && showDownload && (!isPrereleaseStudy(study.access, study.id, permissions)) && (
         <div className={cx()}>
           <div className={cx('Label')}>Download the data</div>
           { study && showDownload && <DownloadLink className="StudySearchIconLinksItem" studyId={study.id} studyUrl={study.downloadUrl.url} attemptAction={attemptAction}/> }
@@ -116,8 +116,8 @@ const mapDispatchToProps = {
 
 export default connect(mapStateToProps, mapDispatchToProps)(StudyRecordHeading);
 
-function isPrivateStudy(access, studyId, user, permissions) {
-  return access === 'private' && !isUserFullyApprovedForStudy(permissions, user.properties.approvedStudies, studyId);
+function isPrivateStudy(access, studyId, permissions) {
+  return access === 'private' && !isUserFullyApprovedForStudy(permissions, studyId);
 }
 
 function UserLink({ to, user, children }) {

--- a/Client/src/wrapWdkService.js
+++ b/Client/src/wrapWdkService.js
@@ -26,10 +26,5 @@ export default wdkService => ({
     useCache: false,
     method: 'get',
     path: '/site-messages'
-  }),
-  getCurrentUser: async () => {
-    let user = await wdkService.getCurrentUser();
-    user.properties.skipStudyPermissions = !useEda;
-    return user;
-  }
+  })
 });

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -1310,6 +1310,47 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
+"@veupathdb/components@^0.11.27":
+  version "0.11.27"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.27.tgz#4654c210a978af04cf38599556f4ef4725bcefb4"
+  integrity sha512-nJC4MzApWSMR25NQ1Db3QHIFNNr5y2+YovdXNomax4MdtFZrr1ER9RoxqtmftzDzbq6+GjtvdAKFnDjRpusjIg==
+  dependencies:
+    "@emotion/react" "^11.7.0"
+    "@material-ui/core" "^4.11.2"
+    "@material-ui/icons" "^4.11.2"
+    "@material-ui/lab" "^4.0.0-alpha.57"
+    "@types/d3" "^7.1.0"
+    "@types/date-arithmetic" "^4.1.1"
+    "@veupathdb/core-components" "^0.4.0"
+    "@visx/gradient" "^1.0.0"
+    "@visx/group" "^1.0.0"
+    "@visx/hierarchy" "^1.0.0"
+    "@visx/shape" "^1.4.0"
+    "@visx/text" "^1.3.0"
+    "@visx/tooltip" "^1.3.0"
+    "@visx/visx" "^1.1.0"
+    bootstrap "^4.5.2"
+    color-math "^1.1.3"
+    d3 "^7.1.1"
+    date-arithmetic "^4.1.0"
+    debounce-promise "^3.1.2"
+    latlon-geohash "^2.0.0"
+    leaflet "^1.6.0"
+    leaflet-drift-marker "^1.0.3"
+    leaflet-simple-map-screenshoter "^0.4.5"
+    luxon "^1.25.0"
+    plotly.js "^2.6.0"
+    re-resizable "^6.9.0"
+    react "^16.13.1"
+    react-bootstrap "^1.3.0"
+    react-cool-dimensions "^1.1.11"
+    react-dom "^16.13.1"
+    react-html-parser "^2.0.2"
+    react-leaflet "^2.7.0"
+    react-plotly.js "^2.4.0"
+    react-transition-group "^4.4.1"
+    shape2geohash "^1.2.5"
+
 "@veupathdb/components@^0.11.8":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.14.tgz#f8a3d4e2c20bdbaa75657763d4bf2ac5a56188f2"
@@ -1382,10 +1423,10 @@
     react-responsive-modal "^6.2.0"
     react-table "^7.7.0"
 
-"@veupathdb/eda@^1.7.8":
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/@veupathdb/eda/-/eda-1.7.8.tgz#5ae0c19bda892a6f9fa3d8d520c5582995c8f188"
-  integrity sha512-cYK5s0/1yHURJ1TjueEhRMWC1AN1paGMse+fNbsQzDK7K4F9bzPHHx5Grj+XPwxRFd8eSj+Sm9q742ZP7bR1ng==
+"@veupathdb/eda@^1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@veupathdb/eda/-/eda-1.8.3.tgz#ec18949aeb13502875be0ca0b833f503e6b88f72"
+  integrity sha512-dkzlsnz2BfTfuIApu5B84zLpqfdrN+TDt4w+u+GyzhNUo++oSc80+7g02hI9a5mP8gctVXCN+kNWVluG9u3vWw==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"
@@ -1393,10 +1434,9 @@
     "@material-ui/icons" "^4.11.2"
     "@material-ui/lab" "^4.0.0-alpha.58"
     "@types/debounce-promise" "^3.1.3"
-    "@veupathdb/components" "^0.11.23"
+    "@veupathdb/components" "^0.11.27"
     "@veupathdb/coreui" "^0.13.0"
     "@veupathdb/http-utils" "^1.1.0"
-    "@veupathdb/study-data-access" "^0.1.5"
     debounce-promise "^3.1.2"
     fp-ts "^2.9.3"
     io-ts "^2.2.13"
@@ -1412,7 +1452,7 @@
     react-table "^7.7.0"
     uuid "^8.3.2"
 
-"@veupathdb/http-utils@^1.0.1", "@veupathdb/http-utils@^1.1.0":
+"@veupathdb/http-utils@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@veupathdb/http-utils/-/http-utils-1.1.0.tgz#fb563593aae2dd7f32eb634ea9776793b35be65f"
   integrity sha512-pkDxTCCq2y7G7tjtFSKe3I7V/SP4jpMuvRQK1HW7c8j/uQDo4a0qLbfsdaZZ/QmVUjapPYh9JS08ehd/UnDljg==
@@ -1431,16 +1471,6 @@
     react-app-rewired "^2.1.8"
     read "^1.0.7"
     set-cookie-parser "^2.4.6"
-
-"@veupathdb/study-data-access@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.1.5.tgz#8f0aae7c4c35f001b8f3bff77feeeba3c86df578"
-  integrity sha512-CPoQ03Hg8O35JaAbhx0g22eAHOaDQ14pvydjMEs1oYFQggw6+cckp6tEpOCHhbAlwIBn0rvSdntGeJho2iLY/w==
-  dependencies:
-    "@veupathdb/http-utils" "^1.0.1"
-    fp-ts "^2.11.5"
-    io-ts "^2.2.16"
-    lodash "^4.17.21"
 
 "@veupathdb/wdk-client@^0.5.7":
   version "0.5.7"


### PR DESCRIPTION
This PR relates to
- `web-study-data-access` [PR 8](https://github.com/VEuPathDB/web-study-data-access/pull/8)
- `web-eda` [PR 982](https://github.com/VEuPathDB/web-eda/pull/982)

## Notable changes
1. Removes all instances of `approvedStudies`
2. Removes `skipStudyPermissions` flag and the `getCurrentUser` override
3. upgrade version of `eda` and `study-data-access` (In progress)


## Open questions
1. I also found a few other instances of `user` involved in the files I changed. For example, `connect(state => ({user: state.globalData.user}), { attemptAction })` in `DownloadLink.jsx`. Or `user` is sent to another component in `StudyAnswerController.jsx`. Should these get removed as well? Seems like they could be removed but i don't fully understand these uses so i didn't remove them just yet.

## Testing
Tested clinepi dev (see also ClinEpiWebsite [PR 25](https://github.com/VEuPathDB/ClinEpiWebsite/pull/25))
Tested mbio legacy with linked web-common and no other chnages. No errors.
Tested mbio eda feature site branch with linked web-common and upgraded study-data-access. No errors. Works great! 