### PR TITLE
Unify tooltips on homepages

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"
@@ -31,9 +31,9 @@
     "whatwg-fetch": "^3.5.0"
   },
   "peerDependencies": {
-    "@veupathdb/components": "^0.13.0",
-    "@veupathdb/eda": "^2.0.0",
-    "@veupathdb/wdk-client": ">=0.5.4",
+    "@veupathdb/components": "^0.14.4",
+    "@veupathdb/eda": "^2.1.8",
+    "@veupathdb/wdk-client": ">=0.6.7",
     "react": ">=16.14",
     "react-dom": ">=16.14"
   },
@@ -49,11 +49,11 @@
     "@types/react-router": "^5.1.18",
     "@types/react-router-dom": "^5.3.3",
     "@types/shelljs": "^0.8.8",
-    "@veupathdb/components": "^0.13.0",
+    "@veupathdb/components": "^0.14.4",
     "@veupathdb/coreui": "^0.16.0",
-    "@veupathdb/eda": "^1.7.8",
+    "@veupathdb/eda": "^2.1.8",
     "@veupathdb/react-scripts": "^1.2.0",
-    "@veupathdb/wdk-client": "^0.6.1",
+    "@veupathdb/wdk-client": "^0.6.7",
     "bubleify": "^2.0.0",
     "icon-font-generator": "^2.1.11",
     "ify-loader": "^1.1.0",

--- a/Client/package.json
+++ b/Client/package.json
@@ -39,6 +39,8 @@
   },
   "devDependencies": {
     "@emotion/react": "^11.7.0",
+    "@emotion/serialize": "^1.0.2",
+    "@emotion/styled": "^11.7.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
@@ -52,7 +54,9 @@
     "@veupathdb/components": "^0.14.4",
     "@veupathdb/coreui": "^0.16.0",
     "@veupathdb/eda": "^2.1.8",
+    "@veupathdb/http-utils": "^1.1.0",
     "@veupathdb/react-scripts": "^1.2.0",
+    "@veupathdb/study-data-access": "^0.3.0",
     "@veupathdb/wdk-client": "^0.6.7",
     "bubleify": "^2.0.0",
     "icon-font-generator": "^2.1.11",

--- a/Client/src/App/Categories/CategoryIcon.jsx
+++ b/Client/src/App/Categories/CategoryIcon.jsx
@@ -2,13 +2,12 @@ import './CategoryIcon.css';
 
 import { capitalize } from 'lodash';
 import React from 'react';
-import { Mesa } from '@veupathdb/wdk-client/lib/Components';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
 
-const { AnchoredTooltip } = Mesa;
 import { getCategoryColor } from './CategoryUtils';
 
 class CategoryIcon extends React.Component {
-  render () {
+  render() {
     const { category } = this.props;
     if (!category || category === 'Unknown') return null;
     const categoryName = capitalize(category);
@@ -17,14 +16,11 @@ class CategoryIcon extends React.Component {
 
     return (
       <div style={{ position: 'relative' }}>
-        <AnchoredTooltip
-          debug={true}
-          content={<div><strong>{categoryName}</strong></div>}
-          style={{ width: 'auto', textTransform: 'capitalize' }}>
+        <Tooltip title={categoryName}>
           <span className="CategoryIcon" style={categoryStyle}>
             {category[0].toUpperCase()}
           </span>
-        </AnchoredTooltip>
+        </Tooltip>
       </div>
     );
   }

--- a/Client/src/App/Categories/CategoryIcon.jsx
+++ b/Client/src/App/Categories/CategoryIcon.jsx
@@ -2,12 +2,12 @@ import './CategoryIcon.css';
 
 import { capitalize } from 'lodash';
 import React from 'react';
-import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 
 import { getCategoryColor } from './CategoryUtils';
 
 class CategoryIcon extends React.Component {
-  render() {
+  render () {
     const { category } = this.props;
     if (!category || category === 'Unknown') return null;
     const categoryName = capitalize(category);

--- a/Client/src/App/Categories/CategoryIcon.jsx
+++ b/Client/src/App/Categories/CategoryIcon.jsx
@@ -16,7 +16,7 @@ class CategoryIcon extends React.Component {
 
     return (
       <div style={{ position: 'relative' }}>
-        <Tooltip title={categoryName}>
+        <Tooltip css={{}} title={categoryName}>
           <span className="CategoryIcon" style={categoryStyle}>
             {category[0].toUpperCase()}
           </span>

--- a/Client/src/App/Showcase/CardList.jsx
+++ b/Client/src/App/Showcase/CardList.jsx
@@ -5,6 +5,7 @@ import Select from 'react-select';
 import { Link, RealTimeSearchBox } from '@veupathdb/wdk-client/lib/Components';
 import { projectId } from '@veupathdb/web-common/lib/config';
 import PlaceholderCard from './PlaceholderCard';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
 
 const CLASS_NAME = 'CardList';
 const SHOW_CATEGORIES_DROPDOWN = (projectId === 'MicrobiomeDB');
@@ -38,9 +39,9 @@ export default function CardList(props) {
   } = props;
 
   // state
-  const [ isExpanded, setIsExpanded ] = React.useState(null);
-  const [ filterString, setFilterString ] = React.useState(null);
-  const [ categoryFilter, setCategoryFilter ] = React.useState();
+  const [isExpanded, setIsExpanded] = React.useState(null);
+  const [filterString, setFilterString] = React.useState(null);
+  const [categoryFilter, setCategoryFilter] = React.useState();
 
   // save state to session storage
   React.useEffect(() => {
@@ -63,7 +64,7 @@ export default function CardList(props) {
       sessionStorage.setItem(filterStringStorageKey, filterString);
     }
 
-  }, [ isExpanded, filterString, additionalClassName ]);
+  }, [isExpanded, filterString, additionalClassName]);
 
   if (filterString == null) return null;
 
@@ -73,19 +74,19 @@ export default function CardList(props) {
     `${isExpandable && isExpanded ? EXPANDED_CLASS_NAME : ''} ${additionalClassName}`;
 
   const cardElements = list == null || isEmpty || isLoading
-    ? Array(5).fill(null).map((_, index) => <PlaceholderCard key={index}/>)
+    ? Array(5).fill(null).map((_, index) => <PlaceholderCard key={index} />)
     : list
-    .filter(item => {
-      if (!isExpandable) return true;
-      const searchString = getSearchStringForItem(item);
+      .filter(item => {
+        if (!isExpandable) return true;
+        const searchString = getSearchStringForItem(item);
 
-      return matchPredicate(searchString, filterString);
-    })
-    .filter(item => {
-      if (categoryFilter == null) return true;
-      return item.categories.includes(categoryFilter);
-    })
-    .map((item, index) => renderCard(item, index));
+        return matchPredicate(searchString, filterString);
+      })
+      .filter(item => {
+        if (categoryFilter == null) return true;
+        return item.categories.includes(categoryFilter);
+      })
+      .map((item, index) => renderCard(item, index));
 
   const cardList = cardElements.length > 0
     ? <div className={LIST_CLASS_NAME}>{cardElements}</div>
@@ -111,14 +112,16 @@ export default function CardList(props) {
     ? `Hide expanded view and list all ${contentNamePlural} horizontally`
     : `Show expanded view and search for specific ${contentNamePlural}`
   const expandButton = isExpandable &&
-    <button type="button" className={EXPAND_BUTTON_CLASS_NAME} onClick={() => setIsExpanded(!isExpanded)} title={buttonTitle}>
-      {isExpanded
-        ? <React.Fragment><i className="fa fa-ellipsis-h" aria-hidden="true"></i> Row view</React.Fragment>
-        : <React.Fragment><i className="fa fa-th" aria-hidden="true"></i> Grid view</React.Fragment>
-      }
-    </button>
+    <Tooltip title={buttonTitle}>
+      <button type="button" className={EXPAND_BUTTON_CLASS_NAME} onClick={() => setIsExpanded(!isExpanded)} title={buttonTitle}>
+        {isExpanded
+          ? <React.Fragment><i className="fa fa-ellipsis-h" aria-hidden="true"></i> Row view</React.Fragment>
+          : <React.Fragment><i className="fa fa-th" aria-hidden="true"></i> Grid view</React.Fragment>
+        }
+      </button>
+    </Tooltip>
 
-  const filterInput = isExpandable && 
+  const filterInput = isExpandable &&
     <RealTimeSearchBox
       className={FILTER_CLASS_NAME}
       searchTerm={filterString}
@@ -127,7 +130,7 @@ export default function CardList(props) {
       helpText={`Find ${contentNamePlural} by searching the visible content.`}
     />
 
-// not in clinepi, redmine #43134
+  // not in clinepi, redmine #43134
   const categorySelector = filters && SHOW_CATEGORIES_DROPDOWN &&
     <Select
       placeholder={`Select a ${filtersLabel}`}
@@ -143,7 +146,9 @@ export default function CardList(props) {
       onChange={option => setCategoryFilter(option && option.value)}
     />
   const tableLink = tableViewLink &&
-    <Link to={tableViewLink} className={ALLSTUDIES_LINK_CLASS_NAME} title="View content as a table"><i className="ebrc-icon-table" aria-hidden="true"></i> {tableViewLinkText}</Link>
+    <Tooltip title={"View content as a table"}>
+      <Link to={tableViewLink} className={ALLSTUDIES_LINK_CLASS_NAME} title="View content as a table"><i className="ebrc-icon-table" aria-hidden="true"></i> {tableViewLinkText}</Link>
+    </Tooltip>
 
   return (
     <div className={className}>

--- a/Client/src/App/Showcase/CardList.jsx
+++ b/Client/src/App/Showcase/CardList.jsx
@@ -39,9 +39,9 @@ export default function CardList(props) {
   } = props;
 
   // state
-  const [isExpanded, setIsExpanded] = React.useState(null);
-  const [filterString, setFilterString] = React.useState(null);
-  const [categoryFilter, setCategoryFilter] = React.useState();
+  const [ isExpanded, setIsExpanded ] = React.useState(null);
+  const [ filterString, setFilterString ] = React.useState(null);
+  const [ categoryFilter, setCategoryFilter ] = React.useState();
 
   // save state to session storage
   React.useEffect(() => {
@@ -64,7 +64,7 @@ export default function CardList(props) {
       sessionStorage.setItem(filterStringStorageKey, filterString);
     }
 
-  }, [isExpanded, filterString, additionalClassName]);
+  }, [ isExpanded, filterString, additionalClassName ]);
 
   if (filterString == null) return null;
 
@@ -74,19 +74,19 @@ export default function CardList(props) {
     `${isExpandable && isExpanded ? EXPANDED_CLASS_NAME : ''} ${additionalClassName}`;
 
   const cardElements = list == null || isEmpty || isLoading
-    ? Array(5).fill(null).map((_, index) => <PlaceholderCard key={index} />)
+    ? Array(5).fill(null).map((_, index) => <PlaceholderCard key={index}/>)
     : list
-      .filter(item => {
-        if (!isExpandable) return true;
-        const searchString = getSearchStringForItem(item);
+    .filter(item => {
+      if (!isExpandable) return true;
+      const searchString = getSearchStringForItem(item);
 
-        return matchPredicate(searchString, filterString);
-      })
-      .filter(item => {
-        if (categoryFilter == null) return true;
-        return item.categories.includes(categoryFilter);
-      })
-      .map((item, index) => renderCard(item, index));
+      return matchPredicate(searchString, filterString);
+    })
+    .filter(item => {
+      if (categoryFilter == null) return true;
+      return item.categories.includes(categoryFilter);
+    })
+    .map((item, index) => renderCard(item, index));
 
   const cardList = cardElements.length > 0
     ? <div className={LIST_CLASS_NAME}>{cardElements}</div>
@@ -130,7 +130,7 @@ export default function CardList(props) {
       helpText={`Find ${contentNamePlural} by searching the visible content.`}
     />
 
-  // not in clinepi, redmine #43134
+// not in clinepi, redmine #43134
   const categorySelector = filters && SHOW_CATEGORIES_DROPDOWN &&
     <Select
       placeholder={`Select a ${filtersLabel}`}

--- a/Client/src/App/Showcase/CardList.jsx
+++ b/Client/src/App/Showcase/CardList.jsx
@@ -112,8 +112,8 @@ export default function CardList(props) {
     ? `Hide expanded view and list all ${contentNamePlural} horizontally`
     : `Show expanded view and search for specific ${contentNamePlural}`
   const expandButton = isExpandable &&
-    <Tooltip title={buttonTitle}>
-      <button type="button" className={EXPAND_BUTTON_CLASS_NAME} onClick={() => setIsExpanded(!isExpanded)} title={buttonTitle}>
+    <Tooltip css={{}} title={buttonTitle}>
+      <button type="button" className={EXPAND_BUTTON_CLASS_NAME} onClick={() => setIsExpanded(!isExpanded)}>
         {isExpanded
           ? <React.Fragment><i className="fa fa-ellipsis-h" aria-hidden="true"></i> Row view</React.Fragment>
           : <React.Fragment><i className="fa fa-th" aria-hidden="true"></i> Grid view</React.Fragment>
@@ -146,8 +146,8 @@ export default function CardList(props) {
       onChange={option => setCategoryFilter(option && option.value)}
     />
   const tableLink = tableViewLink &&
-    <Tooltip title={"View content as a table"}>
-      <Link to={tableViewLink} className={ALLSTUDIES_LINK_CLASS_NAME} title="View content as a table"><i className="ebrc-icon-table" aria-hidden="true"></i> {tableViewLinkText}</Link>
+    <Tooltip css={{}} title={"View content as a table"}>
+      <Link to={tableViewLink} className={ALLSTUDIES_LINK_CLASS_NAME}><i className="ebrc-icon-table" aria-hidden="true"></i> {tableViewLinkText}</Link>
     </Tooltip>
 
   return (

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -131,7 +131,7 @@ class StudyCard extends React.Component {
       <div className={'Card StudyCard ' + (disabled ? 'disabled' : '') + ' StudyCard__' + id}>
         <div className="box StudyCard-Heading">
           <h2>
-            <Tooltip title={myStudyTitle}>
+            <Tooltip css={{}} title={myStudyTitle}>
               <Link to={useEda ? edaRoute + '/details' : route}>{safeHtml(name)}</Link>
             </Tooltip>
           </h2>
@@ -142,7 +142,7 @@ class StudyCard extends React.Component {
             <Icon fa="angle-double-right" /> 
           </Link> */}
         </div>
-        <Tooltip title={myStudyTitle}>
+        <Tooltip css={{}} title={myStudyTitle}>
           <Link to={useEda ? edaRoute + '/details' : route} className="StudyCard-DetailsLink">
             <small>Study Details <Icon fa="chevron-circle-right" /></small>
           </Link>

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -12,18 +12,18 @@ import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
 
 
 class StudyCard extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     this.state = { searchType: null };
     this.displaySearchType = this.displaySearchType.bind(this);
     this.clearDisplaySearchType = this.clearDisplaySearchType.bind(this);
   }
 
-  displaySearchType(searchType) {
+  displaySearchType (searchType) {
     this.setState({ searchType });
   }
 
-  clearDisplaySearchType() {
+  clearDisplaySearchType () {
     const searchType = null;
     this.setState({ searchType });
   }
@@ -33,12 +33,12 @@ class StudyCard extends React.Component {
     if (useEda) {
       return (
         <div className="StudyCard-LinkOuts">
-          {// <DownloadLink className="box StudyCard-Download" linkText="Download" iconFirst studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
+         {// <DownloadLink className="box StudyCard-Download" linkText="Download" iconFirst studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
           }
           {analyses?.some(analysis => analysis.studyId === card.id) &&
             <div className="box StudyCard-MyAnalyses">
               <Link to={{ pathname: makeEdaRoute(), search: `?s=${encodeURIComponent(card.name)}` }}>
-                <i className="ebrc-icon-table" /> My analyses
+                <i className="ebrc-icon-table"/> My analyses
               </Link>
             </div>
           }
@@ -47,7 +47,7 @@ class StudyCard extends React.Component {
     }
     else {
       return (
-        <DownloadLink className="box StudyCard-Download" linkText="Download Data" studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction} />
+        <DownloadLink className="box StudyCard-Download" linkText="Download Data" studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
       );
     }
   }
@@ -60,22 +60,22 @@ class StudyCard extends React.Component {
       return (
         <Link className="StudyCard-SearchLink" to={edaRoute}>
           <div className="box StudyCard-PreFooter">
-            {isPrereleaseStudy(card.access, card.id, permissions)
+            { isPrereleaseStudy(card.access, card.id, permissions)
               ? <span title="Please check the study page">Coming Soon!</span>
               : <span>{disabled ? 'Explore Unavailable' : 'Explore The Data'}</span>
             }
           </div>
           <div className="box StudyCard-Footer">
-            {(!isPrereleaseStudy(card.access, card.id, permissions))
-              ? (
-                <div className="box">
-                  <i className="ebrc-icon-edaIcon" />
-                </div>
-              ) : (
-                <div className="emptybox">
-                  &nbsp;
-                </div>
-              )}
+            { (!isPrereleaseStudy(card.access, card.id, permissions))
+             ? (
+               <div className="box">
+                 <i className="ebrc-icon-edaIcon"/>
+               </div>
+             ) : (
+               <div className="emptybox">
+                 &nbsp;
+               </div>
+             )}
           </div>
         </Link>
       );
@@ -86,7 +86,7 @@ class StudyCard extends React.Component {
       return (
         <>
           <div className="box StudyCard-PreFooter">
-            {isPrereleaseStudy(card.access, card.id, permissions)
+            { isPrereleaseStudy(card.access, card.id, permissions)
               ? <span title="Please check the study page">Coming Soon!</span>
               : searchType
                 ? <span>by <b>{searchType}</b></span>
@@ -94,21 +94,21 @@ class StudyCard extends React.Component {
             }
           </div>
           <div className="box StudyCard-Footer">
-            {(!isPrereleaseStudy(card.access, card.id, permissions) && searches.length)
+            { (!isPrereleaseStudy(card.access, card.id, permissions) && searches.length)
               ? searches.map(({ icon, displayName, path }) => {
-                const route = `/search/${path}`;
-                return (
-                  <div
-                    key={path}
-                    className="box"
-                    onMouseEnter={() => this.displaySearchType(displayName)}
-                    onMouseLeave={this.clearDisplaySearchType}>
-                    <Link className="StudyCard-SearchLink" to={route}>
-                      <i className={icon} />
-                    </Link>
-                  </div>
-                );
-              })
+                  const route = `/search/${path}`;
+                  return (
+                    <div
+                      key={path}
+                      className="box"
+                      onMouseEnter={() => this.displaySearchType(displayName)}
+                      onMouseLeave={this.clearDisplaySearchType}>
+                      <Link className="StudyCard-SearchLink" to={route}>
+                        <i className={icon} />
+                      </Link>
+                    </div>
+                  );
+                })
               : (
                 <div className="emptybox">
                   &nbsp;
@@ -120,7 +120,7 @@ class StudyCard extends React.Component {
     }
   }
 
-  render() {
+  render () {
     const { card } = this.props;
     const { id, name, categories, route, headline, points, disabled } = card;
     const myStudyTitle = "Go to the Study Details page";
@@ -136,7 +136,7 @@ class StudyCard extends React.Component {
             </Tooltip>
           </h2>
           <div className="box StudyCard-Categories">
-            {primaryCategory && <CategoryIcon category={primaryCategory} />}
+            {primaryCategory && <CategoryIcon category={primaryCategory}/>}
           </div>
           {/*<Link to={route} target="_blank" title={myStudyTitle}>
             <Icon fa="angle-double-right" /> 

--- a/Client/src/App/Studies/StudyCard.jsx
+++ b/Client/src/App/Studies/StudyCard.jsx
@@ -8,21 +8,22 @@ import DownloadLink from './DownloadLink';
 import { isPrereleaseStudy } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 import './StudyCard.scss';
 import { makeEdaRoute } from 'ebrc-client/routes';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
 
 
 class StudyCard extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.state = { searchType: null };
     this.displaySearchType = this.displaySearchType.bind(this);
     this.clearDisplaySearchType = this.clearDisplaySearchType.bind(this);
   }
 
-  displaySearchType (searchType) {
+  displaySearchType(searchType) {
     this.setState({ searchType });
   }
 
-  clearDisplaySearchType () {
+  clearDisplaySearchType() {
     const searchType = null;
     this.setState({ searchType });
   }
@@ -32,12 +33,12 @@ class StudyCard extends React.Component {
     if (useEda) {
       return (
         <div className="StudyCard-LinkOuts">
-         {// <DownloadLink className="box StudyCard-Download" linkText="Download" iconFirst studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
+          {// <DownloadLink className="box StudyCard-Download" linkText="Download" iconFirst studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
           }
           {analyses?.some(analysis => analysis.studyId === card.id) &&
             <div className="box StudyCard-MyAnalyses">
               <Link to={{ pathname: makeEdaRoute(), search: `?s=${encodeURIComponent(card.name)}` }}>
-                <i className="ebrc-icon-table"/> My analyses
+                <i className="ebrc-icon-table" /> My analyses
               </Link>
             </div>
           }
@@ -46,7 +47,7 @@ class StudyCard extends React.Component {
     }
     else {
       return (
-        <DownloadLink className="box StudyCard-Download" linkText="Download Data" studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction}/>
+        <DownloadLink className="box StudyCard-Download" linkText="Download Data" studyAccess={card.access} studyId={card.id} studyUrl={card.downloadUrl.url} attemptAction={attemptAction} />
       );
     }
   }
@@ -59,22 +60,22 @@ class StudyCard extends React.Component {
       return (
         <Link className="StudyCard-SearchLink" to={edaRoute}>
           <div className="box StudyCard-PreFooter">
-            { isPrereleaseStudy(card.access, card.id, permissions)
+            {isPrereleaseStudy(card.access, card.id, permissions)
               ? <span title="Please check the study page">Coming Soon!</span>
               : <span>{disabled ? 'Explore Unavailable' : 'Explore The Data'}</span>
             }
           </div>
           <div className="box StudyCard-Footer">
-            { (!isPrereleaseStudy(card.access, card.id, permissions))
-             ? (
-               <div className="box">
-                 <i className="ebrc-icon-edaIcon"/>
-               </div>
-             ) : (
-               <div className="emptybox">
-                 &nbsp;
-               </div>
-             )}
+            {(!isPrereleaseStudy(card.access, card.id, permissions))
+              ? (
+                <div className="box">
+                  <i className="ebrc-icon-edaIcon" />
+                </div>
+              ) : (
+                <div className="emptybox">
+                  &nbsp;
+                </div>
+              )}
           </div>
         </Link>
       );
@@ -85,7 +86,7 @@ class StudyCard extends React.Component {
       return (
         <>
           <div className="box StudyCard-PreFooter">
-            { isPrereleaseStudy(card.access, card.id, permissions)
+            {isPrereleaseStudy(card.access, card.id, permissions)
               ? <span title="Please check the study page">Coming Soon!</span>
               : searchType
                 ? <span>by <b>{searchType}</b></span>
@@ -93,21 +94,21 @@ class StudyCard extends React.Component {
             }
           </div>
           <div className="box StudyCard-Footer">
-            { (!isPrereleaseStudy(card.access, card.id, permissions) && searches.length)
+            {(!isPrereleaseStudy(card.access, card.id, permissions) && searches.length)
               ? searches.map(({ icon, displayName, path }) => {
-                  const route = `/search/${path}`;
-                  return (
-                    <div
-                      key={path}
-                      className="box"
-                      onMouseEnter={() => this.displaySearchType(displayName)}
-                      onMouseLeave={this.clearDisplaySearchType}>
-                      <Link className="StudyCard-SearchLink" to={route}>
-                        <i className={icon} />
-                      </Link>
-                    </div>
-                  );
-                })
+                const route = `/search/${path}`;
+                return (
+                  <div
+                    key={path}
+                    className="box"
+                    onMouseEnter={() => this.displaySearchType(displayName)}
+                    onMouseLeave={this.clearDisplaySearchType}>
+                    <Link className="StudyCard-SearchLink" to={route}>
+                      <i className={icon} />
+                    </Link>
+                  </div>
+                );
+              })
               : (
                 <div className="emptybox">
                   &nbsp;
@@ -119,7 +120,7 @@ class StudyCard extends React.Component {
     }
   }
 
-  render () {
+  render() {
     const { card } = this.props;
     const { id, name, categories, route, headline, points, disabled } = card;
     const myStudyTitle = "Go to the Study Details page";
@@ -129,17 +130,23 @@ class StudyCard extends React.Component {
     return (
       <div className={'Card StudyCard ' + (disabled ? 'disabled' : '') + ' StudyCard__' + id}>
         <div className="box StudyCard-Heading">
-          <h2 title={myStudyTitle}><Link to={useEda ? edaRoute + '/details' : route}>{safeHtml(name)}</Link></h2>
+          <h2>
+            <Tooltip title={myStudyTitle}>
+              <Link to={useEda ? edaRoute + '/details' : route}>{safeHtml(name)}</Link>
+            </Tooltip>
+          </h2>
           <div className="box StudyCard-Categories">
-            {primaryCategory && <CategoryIcon category={primaryCategory}/>}
+            {primaryCategory && <CategoryIcon category={primaryCategory} />}
           </div>
           {/*<Link to={route} target="_blank" title={myStudyTitle}>
             <Icon fa="angle-double-right" /> 
           </Link> */}
         </div>
-        <Link to={useEda ? edaRoute + '/details' : route} className="StudyCard-DetailsLink" title={myStudyTitle}>
-          <small>Study Details <Icon fa="chevron-circle-right"/></small>
-        </Link>
+        <Tooltip title={myStudyTitle}>
+          <Link to={useEda ? edaRoute + '/details' : route} className="StudyCard-DetailsLink">
+            <small>Study Details <Icon fa="chevron-circle-right" /></small>
+          </Link>
+        </Tooltip>
         <div className="box StudyCard-Stripe">
           {headline}
         </div>

--- a/Client/src/components/Footer.jsx
+++ b/Client/src/components/Footer.jsx
@@ -4,6 +4,7 @@ import NewWindowLink from './NewWindowLink';
 import { formatReleaseDate } from '../util/formatters';
 
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
 
 import 'ebrc-client/components/homepage/ProjectLink.scss';
 
@@ -40,9 +41,9 @@ export default enhance(function Footer(props) {
     <div className="Footer">
       <div>
         <div>
-            <a href={`//${location.hostname}`}>{displayName}</a>
-            <span>&nbsp;Release {buildNumber}</span>
-            <span style={{whiteSpace: 'nowrap'}}> &nbsp;&nbsp; {releaseDate && formatReleaseDate(releaseDate)}</span>
+          <a href={`//${location.hostname}`}>{displayName}</a>
+          <span>&nbsp;Release {buildNumber}</span>
+          <span style={{ whiteSpace: 'nowrap' }}> &nbsp;&nbsp; {releaseDate && formatReleaseDate(releaseDate)}</span>
         </div>
         <div className="copyright">©{new Date().getFullYear()} The VEuPathDB Project Team</div>
       </div>
@@ -51,11 +52,13 @@ export default enhance(function Footer(props) {
         <ul className="site-icons">
           {projects.map(project =>
             <React.Fragment key={project}>
-              <li title={`${project}.org`} className={projectLinkCx()}>
-                <a href={`https://${project.toLowerCase()}.org`} className={project}>
-                  https://{project.toLowerCase()}.org
+              <Tooltip title={`${project}.org`}>
+                <li className={projectLinkCx()}>
+                  <a href={`https://${project.toLowerCase()}.org`} className={project}>
+                    https://{project.toLowerCase()}.org
                 </a>
-              </li>
+                </li>
+              </Tooltip>
               {
                 project === 'VectorBase' &&
                 <li className="divider"></li>
@@ -70,14 +73,14 @@ export default enhance(function Footer(props) {
           Please <NewWindowLink href={webAppUrl + '/app/contact-us'}>Contact Us</NewWindowLink> with any questions or comments
         </div>
       </div>
-  
+
       {siteAck != null && (<div className="siteAck">
         <a href={siteAck.linkTo}>
-          <img width="120" src={siteAck.imageLocation}/>
+          <img width="120" src={siteAck.imageLocation} />
         </a>
       </div>
       )}
- 
+
     </div>
   );
 });

--- a/Client/src/components/Footer.jsx
+++ b/Client/src/components/Footer.jsx
@@ -52,7 +52,7 @@ export default enhance(function Footer(props) {
         <ul className="site-icons">
           {projects.map(project =>
             <React.Fragment key={project}>
-              <Tooltip title={`${project}.org`}>
+              <Tooltip css={{}} title={`${project}.org`}>
                 <li className={projectLinkCx()}>
                   <a href={`https://${project.toLowerCase()}.org`} className={project}>
                     https://{project.toLowerCase()}.org

--- a/Client/src/components/Footer.jsx
+++ b/Client/src/components/Footer.jsx
@@ -41,9 +41,9 @@ export default enhance(function Footer(props) {
     <div className="Footer">
       <div>
         <div>
-          <a href={`//${location.hostname}`}>{displayName}</a>
-          <span>&nbsp;Release {buildNumber}</span>
-          <span style={{ whiteSpace: 'nowrap' }}> &nbsp;&nbsp; {releaseDate && formatReleaseDate(releaseDate)}</span>
+            <a href={`//${location.hostname}`}>{displayName}</a>
+            <span>&nbsp;Release {buildNumber}</span>
+            <span style={{whiteSpace: 'nowrap'}}> &nbsp;&nbsp; {releaseDate && formatReleaseDate(releaseDate)}</span>
         </div>
         <div className="copyright">©{new Date().getFullYear()} The VEuPathDB Project Team</div>
       </div>
@@ -73,14 +73,14 @@ export default enhance(function Footer(props) {
           Please <NewWindowLink href={webAppUrl + '/app/contact-us'}>Contact Us</NewWindowLink> with any questions or comments
         </div>
       </div>
-
+  
       {siteAck != null && (<div className="siteAck">
         <a href={siteAck.linkTo}>
-          <img width="120" src={siteAck.imageLocation} />
+          <img width="120" src={siteAck.imageLocation}/>
         </a>
       </div>
       )}
-
+ 
     </div>
   );
 });

--- a/Client/src/components/homepage/ProjectLink.tsx
+++ b/Client/src/components/homepage/ProjectLink.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip'
 
 import './ProjectLink.scss';
 
@@ -11,8 +12,10 @@ type ProjectLinkProps = {
 };
 
 export const ProjectLink = ({ projectId }: ProjectLinkProps) =>
-  <div title={`${projectId}.org`} className={cx()}>
-    <a target="_blank" href={`https://${projectId.toLowerCase()}.org`} className={projectId}>
-      https://{projectId.toLowerCase()}.org
+  <Tooltip css={{}} title={`${projectId}.org`}>
+    <div className={cx()}>
+      <a target="_blank" href={`https://${projectId.toLowerCase()}.org`} className={projectId}>
+        https://{projectId.toLowerCase()}.org
     </a>
-  </div>;
+    </div>
+  </Tooltip>;

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -9,12 +9,17 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
-"@babel/helper-module-imports@^7.0.0":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
   integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
   dependencies:
     "@babel/types" "^7.16.7"
+
+"@babel/helper-plugin-utils@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
+  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
@@ -29,6 +34,13 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
+
+"@babel/plugin-syntax-jsx@^7.12.13":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
+  integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.0"
@@ -63,6 +75,24 @@
   integrity sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==
   dependencies:
     commander "^2.15.1"
+
+"@emotion/babel-plugin@^11.7.1":
+  version "11.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz#723b6d394c89fb2ef782229d92ba95a740576e95"
+  integrity sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.2"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.0.13"
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
@@ -111,12 +141,19 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@emotion/is-prop-valid@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz#34ad6e98e871aa6f7a20469b602911b8b11b3a95"
+  integrity sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
-"@emotion/memoize@^0.7.4":
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
@@ -166,6 +203,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
 
+"@emotion/styled@^11.7.0":
+  version "11.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.8.1.tgz#856f6f63aceef0eb783985fa2322e2bf66d04e17"
+  integrity sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/is-prop-valid" "^1.1.2"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/utils" "^1.1.0"
+
 "@emotion/stylis@0.8.5":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
@@ -185,6 +233,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
   integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/utils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
+  integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
 
 "@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
@@ -1001,6 +1054,15 @@
     react-table "^7.7.0"
     uuid "^8.3.2"
 
+"@veupathdb/http-utils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@veupathdb/http-utils/-/http-utils-1.1.0.tgz#fb563593aae2dd7f32eb634ea9776793b35be65f"
+  integrity sha512-pkDxTCCq2y7G7tjtFSKe3I7V/SP4jpMuvRQK1HW7c8j/uQDo4a0qLbfsdaZZ/QmVUjapPYh9JS08ehd/UnDljg==
+  dependencies:
+    fp-ts "^2.11.5"
+    io-ts "^2.2.16"
+    lodash "^4.17.21"
+
 "@veupathdb/react-scripts@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@veupathdb/react-scripts/-/react-scripts-1.2.0.tgz#3aef2d9c4c9d3ca7b8c33ca43cf22419896e90a5"
@@ -1011,6 +1073,15 @@
     react-app-rewired "^2.1.8"
     read "^1.0.7"
     set-cookie-parser "^2.4.6"
+
+"@veupathdb/study-data-access@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.3.1.tgz#319d2c4bcc6e101bc48647b7a2011b1c0d346de3"
+  integrity sha512-buohdGAVNDMJa5S2p+Ob4dn6GeKBO13UAsyJTSztcAH2jfws/+dVGTbPj5TFvmt4PrT4A4CpktyYkYnLtv6KZg==
+  dependencies:
+    fp-ts "^2.11.5"
+    io-ts "^2.2.16"
+    lodash "^4.17.21"
 
 "@veupathdb/wdk-client@^0.6.7":
   version "0.6.7"
@@ -1583,7 +1654,7 @@ babel-plugin-emotion@^10.0.27:
     find-root "^1.1.0"
     source-map "^0.5.7"
 
-babel-plugin-macros@^2.0.0:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -2835,6 +2906,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@^1.11.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
@@ -2993,6 +3069,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+fp-ts@^2.11.5:
+  version "2.11.9"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.9.tgz#bbc204e0932954b59c98a282635754a4b624a05e"
+  integrity sha512-GhYlNKkCOfdjp71ocdtyaQGoqCswEoWDJLRr+2jClnBBq2dnSOtd6QxmJdALq8UhfqCyZZ0f0lxadU4OhwY9nw==
 
 fp-ts@^2.9.3:
   version "2.11.8"
@@ -3560,7 +3641,7 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-io-ts@^2.2.13:
+io-ts@^2.2.13, io-ts@^2.2.16:
   version "2.2.16"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
   integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -9,17 +9,12 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13":
+"@babel/helper-module-imports@^7.0.0":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
   integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
   dependencies:
     "@babel/types" "^7.16.7"
-
-"@babel/helper-plugin-utils@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
-  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
@@ -34,13 +29,6 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
-
-"@babel/plugin-syntax-jsx@^7.12.13":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
-  integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.0"
@@ -75,24 +63,6 @@
   integrity sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==
   dependencies:
     commander "^2.15.1"
-
-"@emotion/babel-plugin@^11.3.0":
-  version "11.7.2"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
-  integrity sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==
-  dependencies:
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/plugin-syntax-jsx" "^7.12.13"
-    "@babel/runtime" "^7.13.10"
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.5"
-    "@emotion/serialize" "^1.0.2"
-    babel-plugin-macros "^2.6.1"
-    convert-source-map "^1.5.0"
-    escape-string-regexp "^4.0.0"
-    find-root "^1.1.0"
-    source-map "^0.5.7"
-    stylis "4.0.13"
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
@@ -141,24 +111,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.1.tgz#cbd843d409dfaad90f9404e7c0404c55eae8c134"
-  integrity sha512-bW1Tos67CZkOURLc0OalnfxtSXQJMrAMV0jZTVGJUPSOd4qgjF3+tTD5CwJM13PHA8cltGW1WGbbvV9NpvUZPw==
-  dependencies:
-    "@emotion/memoize" "^0.7.4"
-
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
-"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
+"@emotion/memoize@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
-"@emotion/react@^11.4.0", "@emotion/react@^11.4.1", "@emotion/react@^11.7.0":
+"@emotion/react@^11.7.0":
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.7.1.tgz#3f800ce9b20317c13e77b8489ac4a0b922b2fe07"
   integrity sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==
@@ -202,17 +165,6 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
-
-"@emotion/styled@^11.3.0":
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.6.0.tgz#9230d1a7bcb2ebf83c6a579f4c80e0664132d81d"
-  integrity sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/babel-plugin" "^11.3.0"
-    "@emotion/is-prop-valid" "^1.1.1"
-    "@emotion/serialize" "^1.0.2"
-    "@emotion/utils" "^1.0.0"
 
 "@emotion/stylis@0.8.5":
   version "0.8.5"
@@ -294,7 +246,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@material-ui/core@^4.11.2", "@material-ui/core@^4.11.3", "@material-ui/core@^4.12.3":
+"@material-ui/core@^4.12.3":
   version "4.12.3"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
   integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
@@ -319,7 +271,7 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
-"@material-ui/lab@^4.0.0-alpha.57", "@material-ui/lab@^4.0.0-alpha.58":
+"@material-ui/lab@^4.0.0-alpha.57":
   version "4.0.0-alpha.60"
   resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
   integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
@@ -763,98 +715,10 @@
     "@turf/helpers" "^5.1.5"
     "@turf/meta" "^5.1.5"
 
-"@types/d3-array@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.2.tgz#71c35bca8366a40d1b8fce9279afa4a77fb0065d"
-  integrity sha512-5mjGjz6XOXKOCdTajXTZ/pMsg236RdiwKPrRPWAEf/2S/+PzwY+LLYShUpeysWaMvsdS7LArh6GdUefoxpchsQ==
-
-"@types/d3-axis@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.1.tgz#6afc20744fa5cc0cbc3e2bd367b140a79ed3e7a8"
-  integrity sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==
-  dependencies:
-    "@types/d3-selection" "*"
-
-"@types/d3-brush@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.1.tgz#ae5f17ce391935ca88b29000e60ee20452c6357c"
-  integrity sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==
-  dependencies:
-    "@types/d3-selection" "*"
-
-"@types/d3-chord@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.1.tgz#54c8856c19c8e4ab36a53f73ba737de4768ad248"
-  integrity sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==
-
-"@types/d3-color@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.0.2.tgz#53f2d6325f66ee79afd707c05ac849e8ae0edbb0"
-  integrity sha512-WVx6zBiz4sWlboCy7TCgjeyHpNjMsoF36yaagny1uXfbadc9f+5BeBf7U+lRmQqY3EHbGQpP8UdW8AC+cywSwQ==
-
 "@types/d3-color@^1":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-1.4.2.tgz#944f281d04a0f06e134ea96adbb68303515b2784"
   integrity sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA==
-
-"@types/d3-contour@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.1.tgz#9ff4e2fd2a3910de9c5097270a7da8a6ef240017"
-  integrity sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==
-  dependencies:
-    "@types/d3-array" "*"
-    "@types/geojson" "*"
-
-"@types/d3-delaunay@*":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.0.tgz#c09953ac7e5460997f693d2d7bf3522e0d4a88e6"
-  integrity sha512-iGm7ZaGLq11RK3e69VeMM6Oqj2SjKUB9Qhcyd1zIcqn2uE8w9GFB445yCY46NOQO3ByaNyktX1DK+Etz7ZaX+w==
-
-"@types/d3-dispatch@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz#a1b18ae5fa055a6734cb3bd3cbc6260ef19676e3"
-  integrity sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==
-
-"@types/d3-drag@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.1.tgz#fb1e3d5cceeee4d913caa59dedf55c94cb66e80f"
-  integrity sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==
-  dependencies:
-    "@types/d3-selection" "*"
-
-"@types/d3-dsv@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.0.tgz#f3c61fb117bd493ec0e814856feb804a14cfc311"
-  integrity sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==
-
-"@types/d3-ease@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.0.tgz#c29926f8b596f9dadaeca062a32a45365681eae0"
-  integrity sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==
-
-"@types/d3-fetch@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.1.tgz#f9fa88b81aa2eea5814f11aec82ecfddbd0b8fe0"
-  integrity sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==
-  dependencies:
-    "@types/d3-dsv" "*"
-
-"@types/d3-force@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.3.tgz#76cb20d04ae798afede1ea6e41750763ff5a9c82"
-  integrity sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==
-
-"@types/d3-format@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.1.tgz#194f1317a499edd7e58766f96735bdc0216bb89d"
-  integrity sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==
-
-"@types/d3-geo@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.0.2.tgz#e7ec5f484c159b2c404c42d260e6d99d99f45d9a"
-  integrity sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==
-  dependencies:
-    "@types/geojson" "*"
 
 "@types/d3-geo@^1.11.1":
   version "1.12.3"
@@ -863,22 +727,10 @@
   dependencies:
     "@types/geojson" "*"
 
-"@types/d3-hierarchy@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.0.2.tgz#ca63f2f4da15b8f129c5b7dffd71d904cba6aca2"
-  integrity sha512-+krnrWOZ+aQB6v+E+jEkmkAx9HvsNAD+1LCD0vlBY3t+HwjKnsBFbpVLx6WWzDzCIuiTWdAxXMEnGnVXpB09qQ==
-
 "@types/d3-hierarchy@^1.1.6":
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz#50657f420d565a06c0b950a4b82eee0a369f2dea"
   integrity sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg==
-
-"@types/d3-interpolate@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz#e7d17fa4a5830ad56fe22ce3b4fac8541a9572dc"
-  integrity sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==
-  dependencies:
-    "@types/d3-color" "*"
 
 "@types/d3-interpolate@^1.3.1":
   version "1.4.2"
@@ -887,47 +739,15 @@
   dependencies:
     "@types/d3-color" "^1"
 
-"@types/d3-path@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.0.0.tgz#939e3a784ae4f80b1fde8098b91af1776ff1312b"
-  integrity sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==
-
 "@types/d3-path@^1", "@types/d3-path@^1.0.8":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
   integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
 
-"@types/d3-polygon@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.0.tgz#5200a3fa793d7736fa104285fa19b0dbc2424b93"
-  integrity sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==
-
-"@types/d3-quadtree@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz#433112a178eb7df123aab2ce11c67f51cafe8ff5"
-  integrity sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==
-
-"@types/d3-random@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.1.tgz#5c8d42b36cd4c80b92e5626a252f994ca6bfc953"
-  integrity sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==
-
 "@types/d3-random@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-2.2.1.tgz#551edbb71cb317dea2cf9c76ebe059d311eefacb"
   integrity sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA==
-
-"@types/d3-scale-chromatic@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#103124777e8cdec85b20b51fd3397c682ee1e954"
-  integrity sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==
-
-"@types/d3-scale@*":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.2.tgz#41be241126af4630524ead9cb1008ab2f0f26e69"
-  integrity sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==
-  dependencies:
-    "@types/d3-time" "*"
 
 "@types/d3-scale@^3.3.0":
   version "3.3.2"
@@ -936,18 +756,6 @@
   dependencies:
     "@types/d3-time" "^2"
 
-"@types/d3-selection@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.2.tgz#23e48a285b24063630bbe312cc0cfe2276de4a59"
-  integrity sha512-d29EDd0iUBrRoKhPndhDY6U/PYxOWqgIZwKTooy2UkBfU7TNZNpRho0yLWPxlatQrFWk2mnTu71IZQ4+LRgKlQ==
-
-"@types/d3-shape@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.0.2.tgz#4b1ca4ddaac294e76b712429726d40365cd1e8ca"
-  integrity sha512-5+ButCmIfNX8id5seZ7jKj3igdcxx+S9IDBiT35fQGTLZUfkFgTv+oBH34xgeoWDKpWcMITSzBILWQtBoN5Piw==
-  dependencies:
-    "@types/d3-path" "*"
-
 "@types/d3-shape@^1.3.1":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.3.8.tgz#c3c15ec7436b4ce24e38de517586850f1fea8e89"
@@ -955,91 +763,15 @@
   dependencies:
     "@types/d3-path" "^1"
 
-"@types/d3-time-format@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.0.tgz#ee7b6e798f8deb2d9640675f8811d0253aaa1946"
-  integrity sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==
-
-"@types/d3-time@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
-  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
-
 "@types/d3-time@^2", "@types/d3-time@^2.0.0":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
   integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
 
-"@types/d3-timer@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.0.tgz#e2505f1c21ec08bda8915238e397fb71d2fc54ce"
-  integrity sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==
-
-"@types/d3-transition@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.1.tgz#c9a96125567173d6163a6985b874f79154f4cc3d"
-  integrity sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==
-  dependencies:
-    "@types/d3-selection" "*"
-
 "@types/d3-voronoi@^1.1.9":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@types/d3-voronoi/-/d3-voronoi-1.1.9.tgz#7bbc210818a3a5c5e0bafb051420df206617c9e5"
   integrity sha512-DExNQkaHd1F3dFPvGA/Aw2NGyjMln6E9QzsiqOcBgnE+VInYnFBHBBySbZQts6z6xD+5jTfKCP7M4OqMyVjdwQ==
-
-"@types/d3-zoom@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.1.tgz#4bfc7e29625c4f79df38e2c36de52ec3e9faf826"
-  integrity sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==
-  dependencies:
-    "@types/d3-interpolate" "*"
-    "@types/d3-selection" "*"
-
-"@types/d3@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.1.0.tgz#8f32a7e7f434d8f920c8b1ebdfed55e18c033720"
-  integrity sha512-gYWvgeGjEl+zmF8c+U1RNIKqe7sfQwIXeLXO5Os72TjDjCEtgpvGBvZ8dXlAuSS1m6B90Y1Uo6Bm36OGR/OtCA==
-  dependencies:
-    "@types/d3-array" "*"
-    "@types/d3-axis" "*"
-    "@types/d3-brush" "*"
-    "@types/d3-chord" "*"
-    "@types/d3-color" "*"
-    "@types/d3-contour" "*"
-    "@types/d3-delaunay" "*"
-    "@types/d3-dispatch" "*"
-    "@types/d3-drag" "*"
-    "@types/d3-dsv" "*"
-    "@types/d3-ease" "*"
-    "@types/d3-fetch" "*"
-    "@types/d3-force" "*"
-    "@types/d3-format" "*"
-    "@types/d3-geo" "*"
-    "@types/d3-hierarchy" "*"
-    "@types/d3-interpolate" "*"
-    "@types/d3-path" "*"
-    "@types/d3-polygon" "*"
-    "@types/d3-quadtree" "*"
-    "@types/d3-random" "*"
-    "@types/d3-scale" "*"
-    "@types/d3-scale-chromatic" "*"
-    "@types/d3-selection" "*"
-    "@types/d3-shape" "*"
-    "@types/d3-time" "*"
-    "@types/d3-time-format" "*"
-    "@types/d3-timer" "*"
-    "@types/d3-transition" "*"
-    "@types/d3-zoom" "*"
-
-"@types/date-arithmetic@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@types/date-arithmetic/-/date-arithmetic-4.1.1.tgz#03bd30047b71d6eab66f0f03cb14289479ca277a"
-  integrity sha512-o9ILUTMSRiOC73o7h30mgLpuDwOJWqMHZfnEIwNQlfZsGY6Kw2gK5Gz6nXAjNt9zm3Qpr12pM4FDqssfdtBzGA==
-
-"@types/debounce-promise@^3.1.3":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@types/debounce-promise/-/debounce-promise-3.1.4.tgz#bf10eead11724e666ea541df1c9d3969677a505b"
-  integrity sha512-9SEVY3nsz+uMN2DwDocftB5TAgZe7D0cOzxxRhpotWs6T4QFqRaTXpXbOSzbk31/7iYcfCkJJPwWGzTxyuGhCg==
 
 "@types/geojson@*", "@types/geojson@7946.0.8":
   version "7946.0.8"
@@ -1162,13 +894,6 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react-table@^7.7.8":
-  version "7.7.9"
-  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.9.tgz#ea82875775fc6ee71a28408dcc039396ae067c92"
-  integrity sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-transition-group@^4.2.0", "@types/react-transition-group@^4.4.1":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
@@ -1217,51 +942,10 @@
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
-"@veupathdb/components@^0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.12.1.tgz#c91815f221f1773fe24276389b0007136332a978"
-  integrity sha512-D3wrWGCj6f0WIgxvbxfszCRKQ2RUn+lReEzTSjOwrfyAL+FgtrNGBF/pA8UmoHizXAgqhXk3Btt2GuPgR2DwnQ==
-  dependencies:
-    "@emotion/react" "^11.7.0"
-    "@material-ui/core" "^4.11.2"
-    "@material-ui/icons" "^4.11.2"
-    "@material-ui/lab" "^4.0.0-alpha.57"
-    "@types/d3" "^7.1.0"
-    "@types/date-arithmetic" "^4.1.1"
-    "@veupathdb/coreui" "^0.15.1"
-    "@visx/gradient" "^1.0.0"
-    "@visx/group" "^1.0.0"
-    "@visx/hierarchy" "^1.0.0"
-    "@visx/shape" "^1.4.0"
-    "@visx/text" "^1.3.0"
-    "@visx/tooltip" "^1.3.0"
-    "@visx/visx" "^1.1.0"
-    bootstrap "^4.5.2"
-    color-math "^1.1.3"
-    d3 "^7.1.1"
-    date-arithmetic "^4.1.0"
-    debounce-promise "^3.1.2"
-    latlon-geohash "^2.0.0"
-    leaflet "^1.6.0"
-    leaflet-drift-marker "^1.0.3"
-    leaflet-simple-map-screenshoter "^0.4.5"
-    luxon "^1.25.0"
-    plotly.js "^2.6.0"
-    re-resizable "^6.9.0"
-    react "^16.13.1"
-    react-bootstrap "^1.3.0"
-    react-cool-dimensions "^1.1.11"
-    react-dom "^16.13.1"
-    react-html-parser "^2.0.2"
-    react-leaflet "^2.7.0"
-    react-plotly.js "^2.4.0"
-    react-transition-group "^4.4.1"
-    shape2geohash "^1.2.5"
-
-"@veupathdb/components@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.13.0.tgz#5c43164a937fcfbba67f4d32a2be88ee21edfafa"
-  integrity sha512-hS+TP3zVzba/BJUZS88Fa8o932IHo40tRo4kkhfmXhpJwaB6/mS/l4VcVYOicUY6cM4JQCdl72BVXCntj6IxkA==
+"@veupathdb/components@^0.14.4":
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.14.4.tgz#cdb293c265487182878f9757935845cf476332d4"
+  integrity sha512-Rayyxbv2qDJvahD9VX1SBvk1z2M79SCP/B71GDTAYHF9OSd3bV/MCsnVKPbSEbmQCDEonn+klKZ5trMPeVF+9A==
   dependencies:
     "@visx/gradient" "^1.0.0"
     "@visx/group" "^1.0.0"
@@ -1289,25 +973,6 @@
     react-plotly.js "^2.4.0"
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
-
-"@veupathdb/coreui@^0.15.1", "@veupathdb/coreui@^0.15.4":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.15.4.tgz#dac65ffc58fc4106e3c4110b261998bdb696f60b"
-  integrity sha512-Jnpdf6JD865+IBM07MIq0GLaee9D2haKcioXq+kVOPkvrHMeb1+nGjtRaNRplZ09zWS5iuzRc6xsRwnfOCK5Qg==
-  dependencies:
-    "@emotion/react" "^11.4.0"
-    "@emotion/serialize" "^1.0.2"
-    "@emotion/styled" "^11.3.0"
-    "@material-ui/core" "^4.12.3"
-    "@material-ui/icons" "^4.11.2"
-    "@react-hook/size" "^2.1.2"
-    "@types/react-table" "^7.7.8"
-    lodash "^4.17.21"
-    react "^17.0.2"
-    react-cool-dimensions "^2.0.7"
-    react-dom "^17.0.2"
-    react-responsive-modal "^6.2.0"
-    react-table "^7.7.0"
 
 "@veupathdb/coreui@^0.16.0":
   version "0.16.0"
@@ -1320,43 +985,21 @@
     react-responsive-modal "^6.2.0"
     react-table "^7.7.0"
 
-"@veupathdb/eda@^1.7.8":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@veupathdb/eda/-/eda-1.8.5.tgz#4052ce71b22537a4bf4bd3297680c12c4943e8cc"
-  integrity sha512-yiwjPyme69uY7FscPLbjJNvyWttfZ3cKsD4Agj51rc3m4dPXobCD6ZHwZMhA9wQjw3yrBlNGP03Igca5gAI6iQ==
+"@veupathdb/eda@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@veupathdb/eda/-/eda-2.1.8.tgz#161ade83cd65ff92a5b1f2d9c9c89371ffbc89ce"
+  integrity sha512-PQvLXgaf8uNzTd1gH76Ru6QeMYvJSbM5CRpEjByRx0z4c8WzUb+qjMx0SgEvMvoNqz8zHyE5Tt6aaORQUcGFOw==
   dependencies:
-    "@emotion/react" "^11.4.1"
-    "@emotion/styled" "^11.3.0"
-    "@material-ui/core" "^4.11.3"
-    "@material-ui/icons" "^4.11.2"
-    "@material-ui/lab" "^4.0.0-alpha.58"
-    "@types/debounce-promise" "^3.1.3"
-    "@veupathdb/components" "^0.12.1"
-    "@veupathdb/coreui" "^0.15.4"
-    "@veupathdb/http-utils" "^1.1.0"
     debounce-promise "^3.1.2"
     fp-ts "^2.9.3"
     io-ts "^2.2.13"
     lodash "^4.17.21"
     monocle-ts "^2.3.11"
-    react "^17.0.1"
     react-cool-dimensions "^2.0.7"
-    react-dom "^17.0.1"
     react-draggable "^4.4.3"
     react-resizable "^3.0.4"
-    react-router "^5.2.1"
-    react-router-dom "^5.3.0"
     react-table "^7.7.0"
     uuid "^8.3.2"
-
-"@veupathdb/http-utils@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@veupathdb/http-utils/-/http-utils-1.1.0.tgz#fb563593aae2dd7f32eb634ea9776793b35be65f"
-  integrity sha512-pkDxTCCq2y7G7tjtFSKe3I7V/SP4jpMuvRQK1HW7c8j/uQDo4a0qLbfsdaZZ/QmVUjapPYh9JS08ehd/UnDljg==
-  dependencies:
-    fp-ts "^2.11.5"
-    io-ts "^2.2.16"
-    lodash "^4.17.21"
 
 "@veupathdb/react-scripts@^1.2.0":
   version "1.2.0"
@@ -1369,10 +1012,10 @@
     read "^1.0.7"
     set-cookie-parser "^2.4.6"
 
-"@veupathdb/wdk-client@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.6.1.tgz#66cba8329ad2aa84b8d7d18f6cfd3e74f23433b5"
-  integrity sha512-eTKi18NnT4opHp12lPLvUIF+/e1bKP5Q0R1KcGUE38r4RLWmRiCQrccEOgvWcXDL7QBj62p7a270n0zkUI520g==
+"@veupathdb/wdk-client@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.6.7.tgz#2bf512c396c3ff1547195231e01864e80abbc9a1"
+  integrity sha512-YS1Tz0Uoem+ew8ngHtZJQspCAy2ErTgv8yLgvJ2oPpepO53xSeAIqPx0FUGVrUCQaaSwsm0w3ONIy4C+cQ5k9g==
   dependencies:
     classnames "^2.2.0"
     history "^4.10.1"
@@ -1940,7 +1583,7 @@ babel-plugin-emotion@^10.0.27:
     find-root "^1.1.0"
     source-map "^0.5.7"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1:
+babel-plugin-macros@^2.0.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -3192,11 +2835,6 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
 escodegen@^1.11.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
@@ -3356,7 +2994,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-fp-ts@^2.11.5, fp-ts@^2.9.3:
+fp-ts@^2.9.3:
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.8.tgz#411cde116c446d568f5597b03352d8b3f98e8f82"
   integrity sha512-WQT6rP6Jt3TxMdQB3IKzvfZKLuldumntgumLhIUhvPrukTHdWNI4JgEHY04Bd0LIOR9IQRpB+7RuxgUU0Vhmcg==
@@ -3922,7 +3560,7 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-io-ts@^2.2.13, io-ts@^2.2.16:
+io-ts@^2.2.13:
   version "2.2.16"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
   integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==
@@ -5145,7 +4783,7 @@ react-cool-dimensions@^2.0.7:
   resolved "https://registry.yarnpkg.com/react-cool-dimensions/-/react-cool-dimensions-2.0.7.tgz#2fe6657608f034cd7c89f149ed14e79cf1cb2d50"
   integrity sha512-z1VwkAAJ5d8QybDRuYIXTE41RxGr5GYsv1bQhbOBE8cMfoZQZpcF0odL64vdgrQVzat2jayedj1GoYi80FWcbA==
 
-react-dom@16, react-dom@^16.13.1:
+react-dom@16:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -5154,15 +4792,6 @@ react-dom@16, react-dom@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
-
-react-dom@^17.0.1, react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
 
 react-draggable@^4.0.3, react-draggable@^4.4.3:
   version "4.4.4"
@@ -5261,7 +4890,7 @@ react-responsive-modal@^6.2.0:
     body-scroll-lock "^3.1.5"
     classnames "^2.2.6"
 
-react-router-dom@5, react-router-dom@^5.3.0:
+react-router-dom@5:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
   integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
@@ -5274,7 +4903,7 @@ react-router-dom@5, react-router-dom@^5.3.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5, react-router@5.2.1, react-router@^5.2.1:
+react-router@5, react-router@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
   integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
@@ -5336,7 +4965,7 @@ react-use-measure@^2.0.4:
   dependencies:
     debounce "^1.2.1"
 
-react@16, react@^16.13.1:
+react@16:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -5344,14 +4973,6 @@ react@16, react@^16.13.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^17.0.1, react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-package-json@^2.0.2:
   version "2.1.2"
@@ -5722,14 +5343,6 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Addresses [this issue](https://github.com/VEuPathDB/web-eda/issues/984).

This PR accomplishes two things:
1. Replaces `wdk-client` tooltips with the `Tooltip` component from `web-components`
2. Adds the `Tooltip` component from `web-components` to elements that render the browser's default tooltip. This includes the `Footer` components in Plasmo and ClinEpi.

These changes are accompanied by these PRs:
- [WDKClient](https://github.com/VEuPathDB/WDKClient/pull/195)
- [web-components](https://github.com/VEuPathDB/web-components/pull/335)
- [ApiCommonWebsite](https://github.com/VEuPathDB/ApiCommonWebsite/pull/47)