### PR TITLE
Handle 'NA' in column sorting of applicable customSortBy categories

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/component-wrappers/AnswerController.tsx
+++ b/Client/src/component-wrappers/AnswerController.tsx
@@ -70,6 +70,9 @@ const EUPATH_RELEASE_REGEX = new RegExp(/(\w+)\s[\w.]+\s(\d+\.?\d*)\,\s(\d\d\d\d
 const APPROVED_REGEX = new RegExp(/(\d+)/);
 
 const totalToSortKey = memoize((total: AttributeValue) => {
+  if (total === 'NA') {
+    return [ Number.NEGATIVE_INFINITY ]
+  }
   if (typeof total !== 'string') {
     return [ 0 ];
   }
@@ -80,6 +83,9 @@ const totalToSortKey = memoize((total: AttributeValue) => {
   ];
 });
 const approvedToSortKey = memoize((approved: AttributeValue) => {
+  if (approved === 'NA') {
+    return [ Number.NEGATIVE_INFINITY ]
+  }
   if (typeof approved !== 'string') {
     return [ 0 ];
   }
@@ -90,6 +96,9 @@ const approvedToSortKey = memoize((approved: AttributeValue) => {
   ];
 });
 const percentToSortKey = memoize((percentApproved: AttributeValue) => {
+  if (percentApproved === 'NA') {
+    return [ Number.NEGATIVE_INFINITY ]
+  }
   if (typeof percentApproved !== 'string') {
     return [ 0 ];
   }

--- a/Client/src/component-wrappers/AnswerController.tsx
+++ b/Client/src/component-wrappers/AnswerController.tsx
@@ -71,7 +71,7 @@ const APPROVED_REGEX = new RegExp(/(\d+)/);
 
 const totalToSortKey = memoize((total: AttributeValue) => {
   if (total === 'NA') {
-    return [ Number.NEGATIVE_INFINITY ]
+    return [ Number.NEGATIVE_INFINITY ];
   }
   if (typeof total !== 'string') {
     return [ 0 ];
@@ -84,7 +84,7 @@ const totalToSortKey = memoize((total: AttributeValue) => {
 });
 const approvedToSortKey = memoize((approved: AttributeValue) => {
   if (approved === 'NA') {
-    return [ Number.NEGATIVE_INFINITY ]
+    return [ Number.NEGATIVE_INFINITY ];
   }
   if (typeof approved !== 'string') {
     return [ 0 ];
@@ -97,7 +97,7 @@ const approvedToSortKey = memoize((approved: AttributeValue) => {
 });
 const percentToSortKey = memoize((percentApproved: AttributeValue) => {
   if (percentApproved === 'NA') {
-    return [ Number.NEGATIVE_INFINITY ]
+    return [ Number.NEGATIVE_INFINITY ];
   }
   if (typeof percentApproved !== 'string') {
     return [ 0 ];


### PR DESCRIPTION
Addresses the latter part of [this issue](https://github.com/VEuPathDB/WDKClient/issues/192). Specifically, it addresses:
> There is another issue where both blank cells and cells with NA are considered "zero" and so the blank cells do not sort with other blank cells, NA cells do not sort with other NA cells

The desired behavior was articulated as follows:
- Descending order goes `large -> small -> blank -> NA`
- Ascending order goes `NA -> blank -> small -> large`

I tested the changes to `totalToSortKey`, `approvedToSortKey`, and `percentToSortKey` in ClinEpi and Plasmo dev sites, and both sites appear to behave as desired.

The first part of the linked issue is handled in [this PR in `WDKClient`](https://github.com/VEuPathDB/WDKClient/pull/199).