### PR TITLE
Introduce site config for new User Datasets Workspace

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/config.ts
+++ b/Client/src/config.ts
@@ -27,7 +27,9 @@ export const {
   retainContainerContent = false,
   useEda = false,
   edaServiceUrl = '',
-  edaSingleAppMode = undefined
+  edaSingleAppMode = undefined,
+  useUserDatasetsWorkspace = false,
+  datasetImportUrl = '',
 } = window.__SITE_CONFIG__;
 
 const edaExampleAnalysesAuthorNum = parseInt(window.__SITE_CONFIG__.edaExampleAnalysesAuthor ?? '', 10);

--- a/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
+++ b/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
@@ -32,6 +32,8 @@
         {% if eda.single_app_mode is defined %}
         edaSingleAppMode: "{{ eda.single_app_mode }}",
         {% endif -%}
+        useUserDatasetsWorkspace: "true" === "{{ user_datasets_workspace.enabled|default('false')}}",
+        datasetImportUrl: "{{ user_datasets_workspace.import_url|default('') }}"
         {% endblock %}
       };
     </script>

--- a/Model/lib/conifer/roles/conifer/vars/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/default.yml
@@ -175,6 +175,10 @@ eda:
   example_analyses_author:
   service_base_url: "/eda"
 
+user_datasets_workspace:
+  enabled: "false"
+  import_url: "/dataset-import"
+
 contextxml_path: "/{{ _webapp_ctx }}"
 contextxml_docBase: "/var/www/{{ hostname}}/webapp"
 contextxml_model: "{{ project }}"


### PR DESCRIPTION
This PR introduces the following config for the new User Datasets Workspace:

1. A feature flag
2. The URL for the dataset import service (the previous version of the workspace hardcoded this URL)