### PR TITLE
ExternalContentController: fix potential infinite loop when scrolling to the "hash"

### DIFF
--- a/Client/src/controllers/ExternalContentController.tsx
+++ b/Client/src/controllers/ExternalContentController.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useRef } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { usePromise } from '@veupathdb/wdk-client/lib/Hooks/PromiseHook';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
+import { scrollIntoView } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
 
 interface Props {
   url: string;
@@ -12,6 +16,7 @@ const EXTERNAL_CONTENT_CONTROLLER_CLASSNAME = 'ExternalContentController';
 export default function ExternalContentController(props: Props) {
   const { url } = props;
   const ref = useRef<HTMLDivElement>(null);
+  const location = useLocation();
 
   const { value: content } = usePromise(async () => {
     try {
@@ -36,7 +41,9 @@ export default function ExternalContentController(props: Props) {
           target.open = true;
         }
         // scroll to element identified by hash
-        location.assign(location.hash);
+        if (target instanceof HTMLElement) {
+          scrollIntoView(target);
+        }
       }
     }
     catch(error) {


### PR DESCRIPTION
How to reproduce the bug:

1. Check out [this PR](https://github.com/VEuPathDB/ApiCommonWebsite/pull/66)'s branch
2. On the genomics local dev environment, navigate to `https://localhost:3000/a/app/workspace/datasets/help#sample`
3. You'll see an infinite loop of static content network calls (closer inspection reveals that the `ExternalContentController` is being repeatedly mounted and unmounted)

This PR resolves the infinite by changing the way we scroll to the hash specified by the `ExternalContentController`'s url - now, the scrolling is handled by our `scrollIntoView` DOM utility, instead of  `location.assign`.

(To test, `yarn link` / `npm-pack-here` / `relative-deps` this PR's branch to the ApiCommonWebsite branch indicated above. Repeating the steps above should not trigger the infinite loop.)