### PR TITLE
Create reusable JbrowseIframe component

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/components/DatasetGraph.jsx
+++ b/Client/src/components/DatasetGraph.jsx
@@ -3,6 +3,7 @@ import { httpGet } from '../util/http';
 import { CollapsibleSection, Loading, Link } from '@veupathdb/wdk-client/lib/Components';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import ExternalResource from './ExternalResource';
+import { JbrowseIframe } from './JbrowseIframe';
 
 /**
  * Renders an Dataset graph with the provided rowData.
@@ -264,7 +265,12 @@ hook: HostResponseGraphs
                 Non-unique mapping may be examined in the genome browser (<a href={tutorial_link}><b>tutorial</b></a>)
                 <br></br><br></br>
               </div>
-              <div><iframe src={covImgUrl + "&tracklist=0&nav=0&overview=0&fullviewlink=0&meno=0"} width="100%" height="200" scrolling="no" allowfullscreen="false" /></div>
+              <div>
+                <JbrowseIframe
+                  jbrowseUrl={covImgUrl}
+                  height="200"
+                />
+              </div>
             </CollapsibleSection>
           : null}
 
@@ -298,7 +304,12 @@ hook: HostResponseGraphs
                   View in genome browser
                 </a>
               </div>
-              <ExternalResource><iframe src={specialImgUrl.replace('/app/jbrowse', '/jbrowse/index.html') + "&tracklist=0&nav=0&overview=0&fullviewlink=0&meno=0"} width="100%" height="185" scrolling="yes" allowfullscreen="false" /></ExternalResource>
+              <ExternalResource>
+                <JbrowseIframe
+                  jbrowseUrl={specialImgUrl.replace('/app/jbrowse', '/jbrowse/index.html')}
+                  height="185"
+                />
+              </ExternalResource>
               <br></br><br></br>
             </CollapsibleSection>
           : null}

--- a/Client/src/components/JbrowseIframe.tsx
+++ b/Client/src/components/JbrowseIframe.tsx
@@ -1,0 +1,95 @@
+import { Checkbox, HelpIcon } from '@veupathdb/wdk-client/lib/Components';
+import React, { SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
+
+interface Props {
+  jbrowseUrl: string;
+  height: string;
+}
+
+interface JbrowseView {
+  behaviorManager: {
+    removeAll: () => void;
+    initialize: () => void;
+  }
+}
+
+declare global {
+  interface Window {
+    JBrowse: {
+      view: JbrowseView;
+      afterMilestone: (
+        milestoneName: string,
+        callback: (() => void)
+      ) => void;
+    }
+  }
+}
+
+export function JbrowseIframe(props: Props) {
+  const { jbrowseUrl, height } = props;
+  const [ isLocked, setIsLocked ] = useState(true);
+  const onCheckboxToggle = useCallback(
+    newIsUnlockedValue => {
+      setIsLocked(!newIsUnlockedValue);
+    },
+    []
+  );
+
+  const jbrowseViewContainer = useRef<JbrowseView>();
+  const lockText = (
+    <small className="jbrowse-scroll-zoom-toggle-caption">
+      Scroll and zoom
+      {' '}
+      <HelpIcon>
+        <>
+          Select to enable using mouse / track pad for scrolling &amp; zoom
+          <br />
+          (double click to zoom in; shift-double click to zoom out)
+        </>
+      </HelpIcon>
+    </small>
+  );
+
+  useEffect(() => {
+    updateBehaviors();
+  }, [ isLocked ]);
+
+  function onLoad(event: SyntheticEvent<HTMLIFrameElement>) {
+    const JBrowse = event.currentTarget.contentWindow?.JBrowse
+    if (JBrowse == null) throw new Error("Could not load embedded JBrowse instance.");
+    JBrowse.afterMilestone('completely initialized', function() {
+      jbrowseViewContainer.current = window.JBrowse.view;
+      updateBehaviors();
+    });
+  }
+
+  function updateBehaviors() {
+    const view = jbrowseViewContainer.current;
+    if (view == null) return;
+    if (isLocked) view.behaviorManager.removeAll();
+    else view.behaviorManager.initialize();
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          marginBottom: '0.5em'
+        }}
+      >
+        <label className="jbrowse-scroll-zoom-toggle">
+          <Checkbox
+            style={{ marginRight: '0.25em' }}
+            value={!isLocked}
+            onChange={onCheckboxToggle}
+          />
+          {lockText}
+        </label>
+      </div>
+      <iframe onLoad={onLoad} src={jbrowseUrl + "&tracklist=0&nav=1&overview=0&fullviewlink=0&menu=0"} width="100%" height={height} scrolling="no" allowFullScreen={false} />
+    </div>
+  );
+}


### PR DESCRIPTION
Addresses https://redmine.apidb.org/issues/48088.

The code for `JbrowseIframe` is pulled from https://github.com/VEuPathDB/ApiCommonWebsite/blob/1d1a823807d1e243aa0ec15c45cac0bf2d3a112b/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.jsx#L136-L200.