### PR TITLE
Tweak email note and spacing in ContactUs

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/components/ContactUs/ContactUsAttachments.scss
+++ b/Client/src/components/ContactUs/ContactUsAttachments.scss
@@ -13,7 +13,7 @@
   }
 
   .add-file button.btn, .add-another-file button.btn {
-    margin-bottom: 1em;
+    margin-bottom: 0;
     margin-left: 0.5em;
   }
 

--- a/Client/src/components/ContactUs/ContactUsFooter.jsx
+++ b/Client/src/components/ContactUs/ContactUsFooter.jsx
@@ -5,7 +5,6 @@ const ContactUsFooter = ({
   submitDisabled,
   submissionFailed,
   responseMessage,
-  reporterEmailValue
 }) => (
   <tr>
     <td></td>
@@ -15,13 +14,6 @@ const ContactUsFooter = ({
         disabled={submitDisabled}
         value="Submit message" 
       />
-      {
-        !reporterEmailValue ? 
-          <p style={{color: 'darkred', margin: '0.5em 0 0 0', fontSize: '100%'}}>
-            <strong>Note</strong>: Please provide your email if you would like to hear back from us.
-          </p> :
-          null
-      }
       {
         submissionFailed &&
         <ContactUsError 

--- a/Client/src/components/ContactUs/ContactUsForm.jsx
+++ b/Client/src/components/ContactUs/ContactUsForm.jsx
@@ -34,7 +34,10 @@ const ContactUsForm = ({
     event.preventDefault();
     submitDetails();
   }}>
-    <table>
+    <table style={{
+      borderCollapse: 'separate',
+      borderSpacing: '0 0.5em',
+    }}>
       <tbody>
           <SupportFormField
             label="Subject:"
@@ -43,20 +46,25 @@ const ContactUsForm = ({
                 type="text"
                 value={subjectValue}
                 onChange={updateSubject} 
-                size={82}
+                size={80}
               />
             }
           />
           <SupportFormField
             label="Your email address:"
             inputElement={
+              <>
               <ValidatedInput
                 type="text"
                 value={reporterEmailValue}
                 validity={reporterEmailValidity}
                 onChange={updateReporterEmail} 
-                size={82}
+                size={80}
               />
+              <p style={{margin: '3px 0 0 0', fontSize: '0.85em'}}>
+                <em>An email address is required if you would like to hear back from us.</em>
+              </p>
+              </>
             }
           />
           <SupportFormField
@@ -67,7 +75,7 @@ const ContactUsForm = ({
                 value={ccEmailsValue}
                 validity={ccEmailsValidity}
                 onChange={updateCcEmails} 
-                size={82}
+                size={80}
               />
             }
           />
@@ -89,7 +97,7 @@ const ContactUsForm = ({
                 addFile={addFile}
                 removeFile={removeFile}
                 validatedAttachmentMetadata={validatedAttachmentMetadata}
-              />
+                />
             }
           />
           <SupportFormField
@@ -108,7 +116,6 @@ const ContactUsForm = ({
             submitDisabled={submitDisabled}
             submissionFailed={submissionFailed}
             responseMessage={responseMessage}
-            reporterEmailValue={reporterEmailValue}
           />
       </tbody>
     </table>

--- a/Client/src/components/ContactUs/ContactUsScreenshots.scss
+++ b/Client/src/components/ContactUs/ContactUsScreenshots.scss
@@ -24,7 +24,7 @@
   }
 
   &--AddScreenshot.btn {
-    margin-bottom: 1em;
+    margin-bottom: 0;
     margin-left: 0.5em;
   }
 }


### PR DESCRIPTION
Addresses feedback on issue #152 from the 7/27/2022 UX meeting.

Changes made:
- persist the message and place it below the email input field
- add spacing between fields and make it consistent
- change the verbiage of the email note
- make the text of the email note black and italics

![image](https://user-images.githubusercontent.com/69446567/181350159-7c8b344b-c5a5-4cfb-83d0-3776a9090e25.png)