### PR TITLE
Expose the "container" used by the ExternalResource component

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/components/ExternalResource.jsx
+++ b/Client/src/components/ExternalResource.jsx
@@ -45,10 +45,21 @@ export default function ExternalResource(props) {
   });
 
   return (
-    <div style={containerStyle}>
+    <ExternalResourceContainer
+      isLoading={isLoading}
+      isError={isError}
+    >
       {child}
-      {isLoading ? <Loading style={loadingStyle} /> : null}
-      {isError ? <em>Could not load resource.</em> : null}
+    </ExternalResourceContainer>
+  );
+}
+
+export function ExternalResourceContainer(props) {
+  return (
+    <div style={containerStyle}>
+      {props.children}
+      {props.isLoading ? <Loading style={loadingStyle} /> : null}
+      {props.isError ? <em>Could not load resource.</em> : null}
     </div>
   );
 }


### PR DESCRIPTION
Relates to https://github.com/VEuPathDB/ApiCommonWebsite/issues/82. For that issue, I need to pass a custom `onLoad` callback to the `ExternalResource` iframe which renders the RNA-Seq Transcription Summary plot; the existing `ExternalResource` component is not quite up to the task, as that component replaces the iframe's `onLoad` prop with a hardcoded version.