### PR TITLE
Move radiolist body portions outside radiolist

### DIFF
--- a/Client/src/components/reporters/BedGeneReporterForm.jsx
+++ b/Client/src/components/reporters/BedGeneReporterForm.jsx
@@ -105,7 +105,7 @@ let formBeforeCommonOptions = props => {
             { value: 'gene_components', display: 'Gene Components' },
           ]}
         />
-        <h2>Type-specific Params</h2>
+        <h3>Type-specific Params</h3>
         {getTypeSpecificParams()}
       </div>
     </React.Fragment>

--- a/Client/src/components/reporters/BedGeneReporterForm.jsx
+++ b/Client/src/components/reporters/BedGeneReporterForm.jsx
@@ -99,19 +99,11 @@ let formBeforeCommonOptions = props => {
       <h3>Choose the type of result:</h3>
       <div style={{marginLeft:"2em"}}>
         <RadioList name="type" value={formState.type}
-          onChange={typeUpdateHandler} items={
-          [
-            { value: 'genomic', display: 'Unspliced Genomic Region', body:  (
-              <GenomicSequenceRegionInputs formState={formState} getUpdateHandler={getUpdateHandler}/>
-            )},
-            { value: 'spliced_genomic', display: 'Spliced Genomic Region', body: (
-              <FeaturesList field="splicedGenomic" features={splicedGenomicOptions} formState={formState} getUpdateHandler={getUpdateHandler} />
-            )},
-            { value: 'gene_components', display: 'Gene Components', body: (
-              <ComponentsList field="geneComponents" features={geneComponentOptions} formState={formState} getUpdateHandler={getUpdateHandler} />
-            )},
-          ]  
-          }
+          onChange={typeUpdateHandler} items={[
+            { value: 'genomic', display: 'Unspliced Genomic Region' },
+            { value: 'spliced_genomic', display: 'Spliced Genomic Region' },
+            { value: 'gene_components', display: 'Gene Components' },
+          ]}
         />
         {getTypeSpecificParams()}
       </div>

--- a/Client/src/components/reporters/BedGeneReporterForm.jsx
+++ b/Client/src/components/reporters/BedGeneReporterForm.jsx
@@ -105,6 +105,7 @@ let formBeforeCommonOptions = props => {
             { value: 'gene_components', display: 'Gene Components' },
           ]}
         />
+        <h2>Type-specific Params</h2>
         {getTypeSpecificParams()}
       </div>
     </React.Fragment>

--- a/Client/src/components/reporters/BedGeneReporterForm.jsx
+++ b/Client/src/components/reporters/BedGeneReporterForm.jsx
@@ -84,6 +84,16 @@ let formBeforeCommonOptions = props => {
   let typeUpdateHandler = function(newTypeValue) {
     updateFormState(Object.assign({}, formState, { type: newTypeValue }));
   };
+  let getTypeSpecificParams = () => {
+    switch(formState.type) {
+      case 'genomic':
+        return <GenomicSequenceRegionInputs formState={formState} getUpdateHandler={getUpdateHandler}/>;
+      case 'spliced_genomic':
+        return <FeaturesList field="splicedGenomic" features={splicedGenomicOptions} formState={formState} getUpdateHandler={getUpdateHandler} />;
+      case 'gene_components':
+        return <ComponentsList field="geneComponents" features={geneComponentOptions} formState={formState} getUpdateHandler={getUpdateHandler} />;
+    }
+  };
   return (
     <React.Fragment>
       <h3>Choose the type of result:</h3>
@@ -101,7 +111,9 @@ let formBeforeCommonOptions = props => {
               <ComponentsList field="geneComponents" features={geneComponentOptions} formState={formState} getUpdateHandler={getUpdateHandler} />
             )},
           ]  
-          }/>
+          }
+        />
+        {getTypeSpecificParams()}
       </div>
     </React.Fragment>
   );

--- a/Client/src/components/reporters/SequenceFormFactory.jsx
+++ b/Client/src/components/reporters/SequenceFormFactory.jsx
@@ -20,32 +20,30 @@ let sequenceOptions = (props) => {
   return (
     <React.Fragment>
       <h3>Fasta defline:</h3>
-       <div style={{marginLeft:"2em"}}>
-         <RadioList name="deflineType" value={formState.deflineType}
-           onChange={getUpdateHandler('deflineType')} items={[
-             {  value: "short", display: 'ID Only' },
-             { 
-               value: "full", display: 'Full Fasta Header',
-               body: (<ComponentsList field="deflineFields" features={deflineFieldOptions} formState={formState} getUpdateHandler={getUpdateHandler} />),
-             }
-             ]}/>
-       </div>
-       <h3>Sequence format:</h3>
-       <div style={{marginLeft:"2em"}}>
-         <RadioList name="sequenceFormat" value={formState.sequenceFormat}
-           onChange={getUpdateHandler('sequenceFormat')} items={[
-             {  value: "single_line", display: 'Single Line' },
-             { 
-               value: "fixed_width", display: 'Fixed Width',
-               body: (
-                 <React.Fragment>
-                   <span>Bases Per Line: </span>
-                   <NumberSelector name={"basesPerLine"} start={0} end={10000} value={formState["basesPerLine"]} step={1}
-                       onChange={getUpdateHandler("basesPerLine")} size="6"/>
-                 </React.Fragment>
-               ),
-             }
-             ]}/>
+      <div style={{marginLeft:"2em"}}>
+        <RadioList name="deflineType" value={formState.deflineType}
+          onChange={getUpdateHandler('deflineType')} items={[
+            { value: "short", display: 'ID Only' },
+            { value: "full", display: 'Full Fasta Header' },
+          ]}
+        />
+        { formState.deflineType === 'short' ? null :
+          <ComponentsList field="deflineFields" features={deflineFieldOptions} formState={formState} getUpdateHandler={getUpdateHandler} /> }
+      </div>
+      <h3>Sequence format:</h3>
+      <div style={{marginLeft:"2em"}}>
+        <RadioList name="sequenceFormat" value={formState.sequenceFormat}
+          onChange={getUpdateHandler('sequenceFormat')} items={[
+            { value: "single_line", display: 'Single Line' },
+            { value: "fixed_width", display: 'Fixed Width' },
+          ]
+        }/>
+        { formState.sequenceFormat === 'single_line' ? null :
+          <React.Fragment>
+            <span>Bases Per Line: </span>
+            <NumberSelector name={"basesPerLine"} start={0} end={10000} value={formState["basesPerLine"]} step={1}
+              onChange={getUpdateHandler("basesPerLine")} size="6"/>
+          </React.Fragment> }
       </div>
     </React.Fragment>
   );

--- a/Client/src/components/reporters/SequenceGeneReporterForm.jsx
+++ b/Client/src/components/reporters/SequenceGeneReporterForm.jsx
@@ -163,7 +163,7 @@ let formBeforeCommonOptions = props => {
             { value: 'protein_features', display: 'Protein Features' },
           ]}
         />
-        <h2>Type-specific Params</h2>
+        <h3>Type-specific Params</h3>
         {getTypeSpecificParams()}
       </div>
     </React.Fragment>

--- a/Client/src/components/reporters/SequenceGeneReporterForm.jsx
+++ b/Client/src/components/reporters/SequenceGeneReporterForm.jsx
@@ -136,30 +136,34 @@ let formBeforeCommonOptions = props => {
   let typeUpdateHandler = function(newTypeValue) {
     updateFormState(Object.assign({}, formState, { type: newTypeValue }));
   };
+  let getTypeSpecificParams = () => {
+    switch(formState.type) {
+      case 'genomic':
+        return <GenomicSequenceRegionInputs formState={formState} getUpdateHandler={getUpdateHandler}/>;
+      case 'spliced_genomic':
+        return <FeaturesList field="splicedGenomic" features={splicedGenomicOptions} formState={formState} getUpdateHandler={getUpdateHandler} />;
+      case 'gene_components':
+        return <ComponentsList field="geneComponents" features={geneComponentOptions} formState={formState} getUpdateHandler={getUpdateHandler} />;
+      case 'protein':
+        return <ProteinSequenceRegionInputs formState={formState} getUpdateHandler={getUpdateHandler}/>;
+      case 'protein_features':
+        return <FeaturesList field="proteinFeature" features={proteinFeatureOptions} formState={formState} getUpdateHandler={getUpdateHandler} />;
+    }
+  };
   return (
     <React.Fragment>
       <h3>Choose the type of result:</h3>
       <div style={{marginLeft:"2em"}}>
         <RadioList name="type" value={formState.type}
-          onChange={typeUpdateHandler} items={
-          [
-            { value: 'genomic', display: 'Unspliced Genomic Sequence', body:  (
-              <GenomicSequenceRegionInputs formState={formState} getUpdateHandler={getUpdateHandler}/>
-            )},
-            { value: 'spliced_genomic', display: 'Spliced Genomic Sequence', body: (
-              <FeaturesList field="splicedGenomic" features={splicedGenomicOptions} formState={formState} getUpdateHandler={getUpdateHandler} />
-            )},
-            { value: 'gene_components', display: 'Gene Components', body: (
-              <ComponentsList field="geneComponents" features={geneComponentOptions} formState={formState} getUpdateHandler={getUpdateHandler} />
-            )},
-            { value: 'protein', display: 'Protein Sequence', body: (
-              <ProteinSequenceRegionInputs formState={formState} getUpdateHandler={getUpdateHandler}/>
-            )},
-            { value: 'protein_features', display: 'Protein Features', body: (
-              <FeaturesList field="proteinFeature" features={proteinFeatureOptions} formState={formState} getUpdateHandler={getUpdateHandler} />
-            )},
-          ]  
-          }/>
+          onChange={typeUpdateHandler} items={[
+            { value: 'genomic', display: 'Unspliced Genomic Sequence' },
+            { value: 'spliced_genomic', display: 'Spliced Genomic Sequence' },
+            { value: 'gene_components', display: 'Gene Components' },
+            { value: 'protein', display: 'Protein Sequence' },
+            { value: 'protein_features', display: 'Protein Features' },
+          ]}
+        />
+        {getTypeSpecificParams()}
       </div>
     </React.Fragment>
   );

--- a/Client/src/components/reporters/SequenceGeneReporterForm.jsx
+++ b/Client/src/components/reporters/SequenceGeneReporterForm.jsx
@@ -163,6 +163,7 @@ let formBeforeCommonOptions = props => {
             { value: 'protein_features', display: 'Protein Features' },
           ]}
         />
+        <h2>Type-specific Params</h2>
         {getTypeSpecificParams()}
       </div>
     </React.Fragment>


### PR DESCRIPTION
@dmfalke I put this in as a stop gap so I wouldn't have to use the throwaway WdkClient changes.

For Jeremy and Sam: Wojtek added a feature in WdkClient where you can pass a body to a radio option in RadioList that appears when that radio option is selected.  But we decided we don't want that feature.  So this PR is to move the appearance of those bodies below the radio list, but retain the conditional nature of their appearance (only showing when their associated radio option is selected).