### PR TITLE
Identify reference strains in site search org filter

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/controllers/SiteSearchController.tsx
+++ b/Client/src/controllers/SiteSearchController.tsx
@@ -19,12 +19,14 @@ interface Props {
   offerOrganismFilter?: boolean;
   preferredOrganisms?: string[];
   preferredOrganismsEnabled?: boolean;
+  referenceStrains?: Set<string>
 }
 
 export default function SiteSearchController({
   offerOrganismFilter = true,
   preferredOrganisms,
-  preferredOrganismsEnabled
+  preferredOrganismsEnabled,
+  referenceStrains
 }: Props) {
   const [ params, updateParams ] = useQueryParams(
     SEARCH_TERM_PARAM,
@@ -201,6 +203,7 @@ export default function SiteSearchController({
       offerOrganismFilter={offerOrganismFilter}
       onSearch={setSearchString}
       onPageOffsetChange={setOffset}
+      referenceStrains={referenceStrains}
     />
   )
 }


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/50190

Depends on https://github.com/VEuPathDB/ApiCommonWebsite/pull/127

The initial plan was outlined as follows:

1. extract `SiteSearch`'s org filter from web-common and move to `ApiCommon`
2. refactor `SiteSearchController` props to accept a single prop: an optional `additionalFilters`  prop (similar to what we offer with `CheckboxTree`) whose type is a component and whose props will (presumably) be the same as `SiteSearch`
3. leverage hooks/utils from `preferred-organisms` to render the [ Reference ] string in the newly-located/renamed `SiteSearchOrganismFilter` (or similarly coined)

The above approach became messy very quickly as organism-related logic is pretty tightly coupled in `SiteSearch`. I do think we'd like to remove this logic from `web-common` since not all sites have organisms, but I think this is a higher cost than necessary at the moment. Perhaps the refactor is more suited to the second phase wherein a toggle is requested to enable/disable reference strains.

Note: I have tested these changes on ClinEpi and OrthoMCL, neither of which have organisms.