### PR TITLE
Feature: add reference organisms toggle

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/package.json
+++ b/Client/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@veupathdb/components": "^0.19.19",
-    "@veupathdb/coreui": "^0.18.20",
+    "@veupathdb/coreui": "^0.18.21",
     "@veupathdb/eda": "^4.0.0",
     "@veupathdb/wdk-client": "^0.9.29",
     "notistack": "^1.0.10",
@@ -55,7 +55,7 @@
     "@types/react-table": "^7.7.11",
     "@types/shelljs": "^0.8.8",
     "@veupathdb/components": "^0.19.19",
-    "@veupathdb/coreui": "^0.18.20",
+    "@veupathdb/coreui": "^0.18.21",
     "@veupathdb/eda": "^4.0.0",
     "@veupathdb/http-utils": "^1.1.1",
     "@veupathdb/react-scripts": "^2.0.0",

--- a/Client/src/components/SiteSearch/SiteSearch.scss
+++ b/Client/src/components/SiteSearch/SiteSearch.scss
@@ -176,8 +176,8 @@
 
   &--CountsContainer, &--ResultTypeWidgetContainer {
     padding: 1em;
-    width: 24em;
-    max-width: 24em;
+    width: 30em;
+    max-width: 30em;
     // XXX Override in site
     border: 1px solid gray;
     background: whitesmoke;
@@ -401,9 +401,6 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
-    &:hover {
-      font-weight: bold;
-    }
   }
 
   &--LinkOut {

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -269,7 +269,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
       <div className={cx('--OrganismFilterNode')}>
         <div>{node.data.display}{' '}
         {referenceStrains?.has(organismName) && (
-          <span style={{fontSize: '0.9em'}}><strong>[Reference]</strong></span>
+          <span style={{fontSize: '0.95em'}}><strong>[Reference]</strong></span>
         )}
         </div>
         <div>{count.toLocaleString()}</div>

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -332,7 +332,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
         shouldExpandDescendantsWithOneChild
         isSelectable
         selectedList={selection}
-        filteredList={showOnlyReferenceOrganisms && referenceStrains ? Array.from(referenceStrains) : []}
+        filteredList={showOnlyReferenceOrganisms && referenceStrains ? Array.from(referenceStrains) : undefined}
         isAdditionalFilterApplied={showOnlyReferenceOrganisms}
         onSelectionChange={setSelection}
         linksPosition={LinksPosition.Top}

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -240,22 +240,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
   const [ expansion, setExpansion ] = useState<string[]>(initialExpandedNodes);
   const [ selection, setSelection ] = useState<string[]>(filterOrganisms);
   const [ filterTerm, setFilterTerm ] = useState<string>('');
-
-  const [showOnlyReferenceOrganisms, setShowOnlyReferenceOrganisms] = useState(false);
-  const toggleShowOnlyReferenceOrganisms = useCallback(() => {
-    setShowOnlyReferenceOrganisms((value) => !value);
-  }, []);
-  const configTree = useMemo(
-    () =>
-      !showOnlyReferenceOrganisms || !referenceStrains
-        ? organismTree
-        : pruneDescendantNodes(
-            (node) =>
-              node.children.length > 0 || referenceStrains.has(node.data.term),
-            organismTree
-          ),
-    [organismTree, referenceStrains, showOnlyReferenceOrganisms]
-  );
+  const [showOnlyReferenceOrganisms, setShowOnlyReferenceOrganisms] = useState<boolean>(false);
 
   const pendingFilter = !isEqual(selection, filterOrganisms);
   const renderNode = useCallback((node: TreeBoxVocabNode) => {
@@ -333,7 +318,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
         </div>
       </div>
       <CheckboxTree<TreeBoxVocabNode>
-        tree={configTree}
+        tree={organismTree}
         getNodeId={getNodeId}
         getNodeChildren={getNodeChildren}
         isSearchable
@@ -348,6 +333,8 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
         shouldExpandDescendantsWithOneChild
         isSelectable
         selectedList={selection}
+        filteredList={showOnlyReferenceOrganisms && referenceStrains ? Array.from(referenceStrains) : []}
+        isAdditionalFilterApplied={showOnlyReferenceOrganisms}
         onSelectionChange={setSelection}
         linksPosition={LinksPosition.Top}
         additionalFilters={[
@@ -359,8 +346,15 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
               </span>
             }>
               <label className={cx('--OnlyMatchesToggle')}>
-                <input style={{marginRight: '0.25em'}} type="checkbox" checked={showOnlyReferenceOrganisms} onChange={toggleShowOnlyReferenceOrganisms}/>
-                <span style={{fontSize: '1.1em'}}><strong>[Ref]</strong> only</span>
+                <input 
+                  style={{marginRight: '0.25em'}} 
+                  type="checkbox" 
+                  checked={showOnlyReferenceOrganisms} 
+                  onChange={() => setShowOnlyReferenceOrganisms(value => !value)}
+                />
+                <span style={{fontSize: '0.95em'}}>
+                  Reference only
+                </span>
               </label>
           </Tooltip>
         ]}
@@ -377,7 +371,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
           },
           additionalFilters: {
             container: {
-              width: '100px',
+              width: '125px',
               marginLeft: '0.5em',
             }
           }

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -269,7 +269,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
       <div className={cx('--OrganismFilterNode')}>
         <div>{node.data.display}{' '}
         {referenceStrains?.has(organismName) && (
-          <span style={{fontSize: '0.95em'}}><strong>[Reference]</strong></span>
+          <span style={{fontSize: '0.9em'}}><strong>[Ref]</strong></span>
         )}
         </div>
         <div>{count.toLocaleString()}</div>
@@ -281,7 +281,7 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
   const searchPredicate = useCallback((node: TreeBoxVocabNode, searchTerms: string[]) => {
     const organismName = getNodeId(node);
     const display = referenceStrains?.has(organismName) ? 
-      node.data.display + ' [Reference]' : node.data.display;
+      node.data.display + ' [Ref]' : node.data.display;
     return areTermsInString(searchTerms, display);
   }, []);
   const showResetButton = filterOrganisms.length > 0;

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -21,7 +21,6 @@ import { add, capitalize, chunk, intersection, isEmpty, isEqual, keyBy, memoize,
 import React, { ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { CellProps, Column } from 'react-table';
-import Toggle from '@veupathdb/wdk-client/lib/Components/Icon/Toggle';
 import './SiteSearch.scss';
 
 

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -351,18 +351,18 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
         onSelectionChange={setSelection}
         linksPosition={LinksPosition.Top}
         additionalFilters={[
-          <button
-            style={{
-              background: 'none',
-              border: 'none',
-              padding: '0 0.25em',
-              whiteSpace: 'nowrap',
-            }}
-            type="button"
-            onClick={toggleShowOnlyReferenceOrganisms}
-          >
-            <Toggle on={showOnlyReferenceOrganisms} /> Show only reference organisms
-          </button>
+          <Tooltip 
+            css={{}} 
+            title={
+              <span style={{fontWeight: 'normal'}}>
+                Show only reference organisms <span style={{fontWeight: 'bolder'}}>[Ref]</span>
+              </span>
+            }>
+              <label className={cx('--OnlyMatchesToggle')}>
+                <input style={{marginRight: '0.25em'}} type="checkbox" checked={showOnlyReferenceOrganisms} onChange={toggleShowOnlyReferenceOrganisms}/>
+                <span style={{fontSize: '1.1em'}}><strong>[Ref]</strong> only</span>
+              </label>
+          </Tooltip>
         ]}
         styleOverrides={{
           treeSection: {
@@ -375,14 +375,10 @@ function OrganismFilter(props: Required<Pick<Props, 'organismTree' | 'filterOrga
               top: '3px',
             }
           },
-          searchAndFilterWrapper: {
-            flexWrap: 'wrap',
-            rowGap: '0.5em',
-          },
           additionalFilters: {
             container: {
+              width: '100px',
               marginLeft: '0.5em',
-              flexGrow: 1,
             }
           }
         }}

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -1151,10 +1151,10 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
-"@veupathdb/coreui@^0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.18.20.tgz#f5eca391543f46c8cfcc0e5938d20efdeb85bf46"
-  integrity sha512-7xovr/4Ztru6BW7cIUvKGyPIMBXOXL+IDVcpMQPf4RXkxcg1CGdg19JTQVMsqGW35mFV6k/BYMstDuJJAawSAg==
+"@veupathdb/coreui@^0.18.21":
+  version "0.18.21"
+  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.18.21.tgz#635ebf88e535c818151b63caf73241a42ff9659e"
+  integrity sha512-bBJDWVRt9Y7LjysB9w0C5VZ7ZJP5p8o3po47J19Kh9JGgvvMrnJNhe5BpL1XBq6u9Diq1LFphc4lXoPpOTyqUg==
   dependencies:
     "@react-hook/size" "^2.1.2"
     core-js "^3.25.3"


### PR DESCRIPTION
Depends on https://github.com/VEuPathDB/CoreUI/pull/144

Things of note in this iteration:
1. The width of the left panel container has been increased 25%
2. The size of the `[Ref]` string has been reduced slightly
3. The hover effect that bolds the checkbox node has been removed since it enlarges the element which can cause annoying wrapping
4. The "references only" toggle behaves like a search filter by a) expanding the tree, b) preserving checkboxes' indeterminate states, c) rendering the same tree links, and d) removing/disabling the expand/collapse toggles in the rendered tree
5. A tooltip reads "Show only reference organisms **[Ref]**"

![ref_toggle_demo4](https://user-images.githubusercontent.com/69446567/219450135-17a873f6-3747-48aa-936a-06608ae7cf73.gif)
