### PR TITLE
Wire up prototype blocking too-large search strategy exports

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -472,7 +472,6 @@ function StrategyLinkout(props: Props) {
   const question = useWdkService(async wdkService =>
     docType == null || !docType.isWdkRecordType ? undefined :
     wdkService.getQuestionAndParameters(docType.wdkSearchName), [ docType ]);
-  const displayName = useWdkService(async wdkService => (await wdkService.getConfig()).displayName, []);
   const [ loading, setLoading ] = useState(false);
   const [ isMoreFilteringRequired, setIsMoreFilteringRequired ] = useState(false);
 
@@ -558,29 +557,29 @@ function StrategyLinkout(props: Props) {
       >
         <div style={{
           fontSize: '1.1em',
-          minWidth: '400px',
+          minWidth: '425px',
         }}>
           <p style={{
             margin: 0,
           }}>
-            Your result ({response.searchResults.totalCount.toLocaleString()}) is too large to export. The maximum is 50,000.
+            Sorry, your result ({response.searchResults.totalCount.toLocaleString()}) is too large to export. The maximum is 50,000.
           </p>
           <br />
           <p style={{
             margin: 0,
           }}>
-            Please try:
+            Please try to reduce the size of your result by:
             <ul style={{
               marginTop: '0.25em',
             }}>
-              <li>applying an Organism filter</li>
+              <li>filtering the result</li>
               <li>adjusting your search term</li> 
             </ul>
           </p>
           <br />
           {!hasUserSetPreferredOrganisms && 
             <p style={{margin: 0, marginBottom: '1em'}}>
-              Consider using <button type="button" className='link' onClick={() => history.push('/preferred-organisms')}>My Organism Preferences</button> to generally limit the organisms you see{displayName ? ` on ${displayName}.` : '.'}
+              Large results can also be avoided by setting <Link to='/preferred-organisms'>My Organism Preferences</Link> to search only those organisms most relevant to your work.
             </p>}
           <div style={{
             textAlign: 'center',

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -610,7 +610,7 @@ function StrategyLinkout(props: Props) {
           <br />
           {!hasUserSetPreferredOrganisms && 
             <p style={{margin: 0, marginBottom: '1em'}}>
-              Large results can also be avoided by setting <Link to='/preferred-organisms'>My Organism Preferences</Link> to search only those organisms most relevant to your work.
+              Large results can also be avoided by setting <Link to='/preferred-organisms'>My Organism Preferences</Link> to search the subset of organisms most relevant to your work.
             </p>}
           <div style={{
             textAlign: 'center',

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -553,17 +553,17 @@ function StrategyLinkout(props: Props) {
     if (!isMoreFilteringRequired) return;
     return (
       <CommonModal
-        title={'Result Too Large'}
+        title={<><i style={{margin: 'auto 0', marginRight: '0.25em', color: '#CB0'}} className='fa fa-warning'/><span>Result Too Large</span></>}
         onClose={() => setIsMoreFilteringRequired(!isMoreFilteringRequired)} 
       >
         <div style={{
           fontSize: '1.1em',
-          minWidth: '350px',
+          minWidth: '400px',
         }}>
           <p style={{
             margin: 0,
           }}>
-            We're sorry. Your result ({response.searchResults.totalCount.toLocaleString()}) is too large to export. The maximum is 50,000.
+            Your result ({response.searchResults.totalCount.toLocaleString()}) is too large to export. The maximum is 50,000.
           </p>
           <br />
           <p style={{
@@ -573,8 +573,8 @@ function StrategyLinkout(props: Props) {
             <ul style={{
               marginTop: '0.25em',
             }}>
-              <li>adjusting your search term</li> 
               <li>applying an Organism filter</li>
+              <li>adjusting your search term</li> 
             </ul>
           </p>
           <br />

--- a/Client/src/components/SiteSearch/SiteSearch.tsx
+++ b/Client/src/components/SiteSearch/SiteSearch.tsx
@@ -498,7 +498,7 @@ function FieldsHit(props: HitProps) {
 }
 
 function StrategyLinkout(props: Props) {
-  const { response, documentType, filters = [], filterOrganisms = [], searchString, organismTree, hasUserSetPreferredOrganisms } = props;
+  const { response, documentType, filters = [], filterOrganisms = [], searchString, organismTree, hasUserSetPreferredOrganisms, offerOrganismFilter } = props;
   const docType = response.documentTypes.find(d => d.id === documentType);
   const question = useWdkService(async wdkService =>
     docType == null || !docType.isWdkRecordType ? undefined :
@@ -608,7 +608,7 @@ function StrategyLinkout(props: Props) {
             </ul>
           </p>
           <br />
-          {!hasUserSetPreferredOrganisms && 
+          {offerOrganismFilter && !hasUserSetPreferredOrganisms && 
             <p style={{margin: 0, marginBottom: '1em'}}>
               Large results can also be avoided by setting <Link to='/preferred-organisms'>My Organism Preferences</Link> to search the subset of organisms most relevant to your work.
             </p>}

--- a/Client/src/controllers/SiteSearchController.tsx
+++ b/Client/src/controllers/SiteSearchController.tsx
@@ -19,14 +19,16 @@ interface Props {
   offerOrganismFilter?: boolean;
   preferredOrganisms?: string[];
   preferredOrganismsEnabled?: boolean;
-  referenceStrains?: Set<string>
+  referenceStrains?: Set<string>;
+  hasUserSetPreferredOrganisms?: boolean;
 }
 
 export default function SiteSearchController({
   offerOrganismFilter = true,
   preferredOrganisms,
   preferredOrganismsEnabled,
-  referenceStrains
+  referenceStrains,
+  hasUserSetPreferredOrganisms,
 }: Props) {
   const [ params, updateParams ] = useQueryParams(
     SEARCH_TERM_PARAM,
@@ -194,6 +196,7 @@ export default function SiteSearchController({
       onFiltersChange={setFilters}
       filterOrganisms={value.searchSettings.organisms}
       preferredOrganismsEnabled={preferredOrganismsEnabled}
+      hasUserSetPreferredOrganisms={hasUserSetPreferredOrganisms}
       onOrganismsChange={setOrganisms}
       onClearFilters={clearFilters}
       response={value.response}


### PR DESCRIPTION
This is a prototype in response to [redmine#47135](https://redmine.apidb.org/issues/47135).

This works to block exporting search results that are greater than 50,000. Users are presented a message and some suggestions in a modal as shown.

![image](https://user-images.githubusercontent.com/69446567/221002892-482e4ffd-058c-4f32-a710-a02c1070e49b.png)