### PR TITLE
Amend focus styling by removing webkit color and outline-offset

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"

--- a/Client/src/styles/AllSites.scss
+++ b/Client/src/styles/AllSites.scss
@@ -140,9 +140,6 @@ a[name] {
 
 :focus {
   outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-
 }
 a.eupathdb-BigButton,input[type="submit"] {
   color: #3e3e3e;


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/WDKClient/issues/284

The screenshots shown are from Chrome.

Before: Chrome with the `webkit` outline and an `outline-offset` of -2px
![image](https://user-images.githubusercontent.com/69446567/220989403-df48723f-2296-40cb-9593-b2788bb2d587.png)

After: Removed the `webkit` outline to show a more native, uniform thin dotted line when focused
![image](https://user-images.githubusercontent.com/69446567/220988313-c90e2d19-ffaa-4973-a13f-553e48458ea4.png)