### PR TITLE
Refactor large export modal and allow continue export option

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/web-common",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "url": "https://github.com/VEuPathDB/EbrcWebsiteCommon",
     "directory": "Client"


### PR DESCRIPTION
Follow up work described in most recent comment in [this redmine issue](https://redmine.apidb.org/issues/47135).

In sum, it was decided that we should allow users to bypass the large exports modal with a warning rather than blocking users from attempting to export large results.