### PR TITLE
Add gitter-sidecar hack to handle break in Gitter API

### DIFF
--- a/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
+++ b/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
@@ -76,6 +76,34 @@
       ((window.gitter = {}).chat = {}).options = {
         room: '{{ room }}/community'
       };
+      document.addEventListener(
+        'gitter-sidecar-instance-started', 
+        function gitterSidecarHack() {
+          const gitterBtn = document.querySelector('.gitter-open-chat-button');
+          const gitterAside = document.querySelector('.gitter-chat-embed');
+
+          // we want to hide the aside and any loading indicators when button is clicked
+          gitterAside.style.display = 'none';
+          document.querySelector('.gitter-chat-embed-loading-wrapper').style.display = 'none';
+
+          gitterBtn.addEventListener(
+            'click', 
+            function openGitterInNewTab(e) {
+              e.stopPropagation();
+              window.open('https://app.gitter.im/#/room/#VEuPathDB-genomic_community:gitter.im', "_blank");
+            }, 
+            true
+          );
+
+          gitterAside.addEventListener(
+            'gitter-chat-toggle', 
+            function keepGitterBtnVisible() {
+              // we want the chat button to remain visible when clicked
+              gitterBtn.classList.remove('is-collapsed');
+            }
+          )
+        }
+      )
     </script>
     <script src="https://cdn.jsdelivr.net/npm/gitter-sidecar@1.5.0/dist/sidecar.min.js" async defer></script>
   {%- endif %}


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/51057

As mentioned in the article, `gitter-sidecar` broke when Gitter merged with Matrix. It's on their radar as something they may fix, so we may able to revert these changes in the future.

https://gitlab.com/gitterHQ/sidecar/-/issues/82