### PR TITLE
Fix gitter bug in non-FireFox browsers

### DIFF
--- a/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
+++ b/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
@@ -90,7 +90,8 @@
             'click', 
             function openGitterInNewTab(e) {
               e.stopPropagation();
-              window.open('https://app.gitter.im/#/room/#VEuPathDB-genomic_community:gitter.im', "_blank");
+              e.preventDefault();
+              window.open('https://app.gitter.im/#/room/#VEuPathDB-genomic_community:gitter.im', "VEuPathDBGitterForum");
             }, 
             true
           );


### PR DESCRIPTION
The [recent work to open Gitter in a new tab](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/212) was only working with FireFox. Other browsers were opening Gitter in a new tab _**and**_ opening Gitter in the original tab.