### PR TITLE
Add AI Qualtrics feedback ID config var

### DIFF
--- a/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
+++ b/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
@@ -50,6 +50,7 @@
         {% if vdi is defined %}
         vdiServiceUrl: "{{ vdi.service_base_url|default('')}}",
         {% endif %}
+        aiExpressionQualtricsId: "{{ modelprop.AI_EXPRESSION_QUALTRICS_ID|default('') }}",
         {% endblock %}
       };
     </script>

--- a/Model/lib/conifer/roles/conifer/vars/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/default.yml
@@ -159,6 +159,7 @@ modelprop:
   SITE_SEARCH_SERVICE_URL:
   OPENAI_API_KEY:
   AI_EXPRESSION_CACHE_DIR: /eupath/ai-expr-cache
+  AI_EXPRESSION_QUALTRICS_ID: SV_38C4ZX1JxLi2SEe
 
 eda:
   enabled: "true"


### PR DESCRIPTION
This is currently targeting `api-legacy-68-f`. Maybe we need to merge it into `api-legacy-68-g`, which is fine!  And maybe also `master`?