### PR TITLE
AI-assisted user comments feature flag

### DIFF
--- a/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
+++ b/Model/lib/conifer/roles/conifer/templates/EbrcWebsiteCommon/appBase.html.j2
@@ -61,6 +61,7 @@
         vdiServiceUrl: "{{ vdi.service_base_url|default('')}}",
         {% endif %}
         aiExpressionQualtricsId: "{{ modelprop.AI_EXPRESSION_QUALTRICS_ID|default('') }}",
+        allowAiAssistedCommentCreation: "true" === "{{ modelprop.ALLOW_AI_ASSISTED_COMMENT_CREATION|default('false') }}",
         {% endblock %}
       };
     </script>

--- a/Model/lib/conifer/roles/conifer/vars/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/default.yml
@@ -174,6 +174,7 @@ modelprop:
   LINKEDIN_URL:
   SITE_SEARCH_SERVICE_URL:
   OPENAI_API_KEY:
+  ALLOW_AI_ASSISTED_COMMENT_CREATION: 'true'
   EDA_SERVICE_URL: /eda
   VDI_SERVICE_URL: /vdi
   INVOICE_FORM_URL: 'https://upenn.co1.qualtrics.com/jfe/form/SV_56yc5QpxL0IfWkK'


### PR DESCRIPTION
Source of truth for the AI-assisted comment creation feature flag. Defaults on ('true'); flipped to 'false' only in special circumstances. Rendered into window.__SITE_CONFIG__.allowAiAssistedCommentCreation for the frontend and read by AiGenePublicationCommentService on the backend.