### PR TITLE
Fix mojibake in RNASeq line-plot data by forcing UTF-8 decode

### DIFF
--- a/View/lib/perl/GraphPackage/GGLinePlot.pm
+++ b/View/lib/perl/GraphPackage/GGLinePlot.pm
@@ -137,7 +137,8 @@ sub makeRPlotString {
   push @{ $ua->requests_redirectable }, 'POST';
   my $resp = $ua->request($profileSetsRequest);
   if ($resp->is_success) {
-    $plotDataJson = $resp->decoded_content;
+    # Force UTF-8 decoding; the service sends it but omits the charset param.
+    $plotDataJson = $resp->decoded_content(charset => 'UTF-8');
     $plotDataJson =~ s/\'/\\\'/g;
   } else {
     print "HTTP POST error code: ", $resp->code, "\n";


### PR DESCRIPTION
## Summary
- `GGLinePlot::makeRPlotString` reads the WDK PlotData service response via `$resp->decoded_content`, which falls back to Latin-1 when the response's `Content-Type: application/json` omits a charset — corrupting any non-ASCII byte (e.g. a presenter display name containing "Delta").
- For datasets whose display name is long and repeats per data point, the resulting single R string literal exceeds 10,000 characters. R's parser only enforces its "Unicode escapes not in this locale" length cap on strings needing escape handling, and the mojibake control character forces that path — so the R script fails to parse and the graph dies with `Couldn't run R program: 256`. A correctly-decoded string of the same length is unaffected.
- Fix: force `decoded_content(charset => 'UTF-8')`, the charset the service actually sends. One line, no WDK service change, no dataset presenter rename/rebuild needed.

Found while debugging `https://b2.fungidb.org/cgi-bin/dataPlotter.pl?...&datasetId=DS_c05fd37f3c` (NCU08345, `ncraOR74A_Bharath_Circadian_Time_Course_ebi_rnaSeq_RSRC` — display name contains "ΔMSN1"). Verified fixed by rebuilding (`wb graph`) against this branch.

## Test plan
- [x] Reproduced the crash by running `dataPlotter.pl` directly (bypassing Apache) and capturing the generated R script mid-flight; confirmed the exact R parser error
- [x] Confirmed a correctly UTF-8-decoded string of equivalent length does not trip R's parser limit
- [x] Rebuilt FungiDB dev site (`wb graph`) against this branch — graph now renders
- [ ] Consider applying the same fix to `GGBarPlot.pm`/`GGPiePlot.pm`, which have the identical `decoded_content` pattern (not yet triggered by any bar/pie dataset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
