### PR TITLE
Apply UTF-8 decode fix to GGBarPlot.pm and GGPiePlot.pm

### DIFF
--- a/View/lib/perl/GraphPackage/GGBarPlot.pm
+++ b/View/lib/perl/GraphPackage/GGBarPlot.pm
@@ -86,7 +86,8 @@ sub makeRPlotString {
   my $resp = $ua->request($profileSetsRequest);
 
   if ($resp->is_success) {
-    $plotDataJson = $resp->decoded_content;
+    # Force UTF-8 decoding; the service sends it but omits the charset param.
+    $plotDataJson = $resp->decoded_content(charset => 'UTF-8');
     $plotDataJson =~ s/\'/\\\'/g;
   } else {
     print "HTTP POST error code: ", $resp->code, "\n";

--- a/View/lib/perl/GraphPackage/GGPiePlot.pm
+++ b/View/lib/perl/GraphPackage/GGPiePlot.pm
@@ -56,7 +56,8 @@ sub makeRPlotString {
   push @{ $ua->requests_redirectable }, 'POST';
   my $resp = $ua->request($profileSetsRequest);
   if ($resp->is_success) {
-    $plotDataJson = $resp->decoded_content;
+    # Force UTF-8 decoding; the service sends it but omits the charset param.
+    $plotDataJson = $resp->decoded_content(charset => 'UTF-8');
     $plotDataJson =~ s/\'/\\\'/g;
   } else {
     print "HTTP POST error code: ", $resp->code, "\n";


### PR DESCRIPTION
## Summary
- Follow-up to #254, which fixed `GGLinePlot.pm` but merged before this branch's second commit reached GitHub.
- Applies the identical `decoded_content(charset => 'UTF-8')` fix to `GGBarPlot.pm` and `GGPiePlot.pm` — same latent bug, same code pattern, not yet observed to crash a bar/pie graph but equally exposed for any dataset with a long, non-ASCII display name.

## Test plan
- [x] Same fix pattern as #254, applied identically
- [ ] No bar/pie dataset currently known to trigger the crash; this is preventative

🤖 Generated with [Claude Code](https://claude.com/claude-code)
